### PR TITLE
Install truffle and ethereumjs-testrpc as devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Lif is also a DAO, the token holders can create proposals to change token variab
 ## Install
 
 ```sh
-npm install ethereumjs-testrpc -g
-npm install truffle -g
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "solc": "^0.4.9",
     "zeppelin-solidity": "^1.0.1"
   },
+  "devDependencies": {
+    "ethereumjs-testrpc": "3.0.3",
+    "truffle": "3.2.1"
+  },
   "jshintConfig": {
     "esversion": 6
   }


### PR DESCRIPTION
Makes installation easier and uses explicit version numbers