### PR TITLE
Rename format/parseBalance methods to lif2LifWei form

### DIFF
--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -123,7 +123,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(auctionSuccess[8]), 40);
     assert.equal(parseInt(auctionSuccess[9]), 385);
     assert.equal(help.toEther(auctionSuccess[10]), 250000);
-    assert.equal(help.parseBalance(auctionSuccess[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(auctionSuccess[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(auctionSuccess[12]), totalTokensBought);
     assert.equal(parseFloat(auctionSuccess[13]), lastPrice);
     presaleTokens = help.toWei(250000)/(lastPrice*0.6);
@@ -147,7 +147,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(auctionEnded[8]), 40);
     assert.equal(parseInt(auctionEnded[9]), 0);
     assert.equal(help.toEther(auctionEnded[10]), 250000);
-    assert.equal(help.parseBalance(auctionEnded[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(auctionEnded[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(auctionEnded[12]), totalTokensBought);
     assert.equal(parseFloat(auctionEnded[13]), lastPrice);
 
@@ -180,7 +180,7 @@ contract('LifToken Crowdsale', function(accounts) {
     await token.claimTokensPayment(7, {from: accounts[0]});
     await token.claimTokensPayment(8, {from: accounts[0]});
     let ownerBalance = await token.balanceOf(accounts[0]);
-    assert.equal(help.parseBalance(ownerBalance), 2695000);
+    assert.equal(help.lifWei2Lif(ownerBalance), 2695000);
     // Check all final values
     await help.checkValues(token, accounts, 0, 9995000, 0, [500000, 1000000, 500000, 1000000, 2000000]);
   });
@@ -272,7 +272,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(auctionSuccess[8]), 50);
     assert.equal(parseInt(auctionSuccess[9]), 428);
     assert.equal(help.toEther(auctionSuccess[10]), 250000);
-    assert.equal(help.parseBalance(auctionSuccess[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(auctionSuccess[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(auctionSuccess[12]), totalTokensBought);
     assert.equal(parseFloat(auctionSuccess[13]), lastPrice);
     presaleTokens = help.toWei(250000)/(lastPrice*0.5);
@@ -295,7 +295,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(auctionEnded[8]), 50);
     assert.equal(parseInt(auctionEnded[9]), 0);
     assert.equal(help.toEther(auctionEnded[10]), 250000);
-    assert.equal(help.parseBalance(auctionEnded[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(auctionEnded[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(auctionEnded[12]), totalTokensBought);
     assert.equal(parseFloat(auctionEnded[13]), lastPrice);
     // Distribute the sold tokens and check the values
@@ -375,7 +375,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(auctionSuccess[8]), 0);
     assert.equal(parseInt(auctionSuccess[9]), 428);
     assert.equal(help.toEther(auctionSuccess[10]), 0);
-    assert.equal(help.parseBalance(auctionSuccess[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(auctionSuccess[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(auctionSuccess[12]), totalTokensBought);
     assert.equal(parseFloat(auctionSuccess[13]), lastPrice);
 
@@ -398,7 +398,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(auctionEnded[8]), 0);
     assert.equal(parseInt(auctionEnded[9]), 0);
     assert.equal(help.toEther(auctionEnded[10]), 0);
-    assert.equal(help.parseBalance(auctionEnded[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(auctionEnded[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(auctionEnded[12]), totalTokensBought);
     assert.equal(parseFloat(auctionEnded[13]), lastPrice);
 
@@ -470,7 +470,7 @@ contract('LifToken Crowdsale', function(accounts) {
     assert.equal(parseFloat(thirdAuctionEnded[8]), 0);
     assert.equal(parseInt(thirdAuctionEnded[9]), 0);
     assert.equal(help.toEther(thirdAuctionEnded[10]), 0);
-    assert.equal(help.parseBalance(thirdAuctionEnded[11]), help.parseBalance(totalWeiSent));
+    assert.equal(help.lifWei2Lif(thirdAuctionEnded[11]), help.lifWei2Lif(totalWeiSent));
     assert.equal(parseFloat(thirdAuctionEnded[12]), totalTokensBought);
     assert.equal(parseFloat(thirdAuctionEnded[13]), lastPrice);
 
@@ -509,7 +509,7 @@ contract('LifToken Crowdsale', function(accounts) {
     await token.claimTokensPayment(22, {from: accounts[0]});
     await token.claimTokensPayment(23, {from: accounts[0]});
     let ownerBalance = await token.balanceOf(accounts[0]);
-    assert.equal(help.parseBalance(ownerBalance), 2995992);
+    assert.equal(help.lifWei2Lif(ownerBalance), 2995992);
 
     // Check all final values
     await help.checkValues(token, accounts, 0, 9995992, 0, [875000, 700000, 500000, 700000, 500000]);

--- a/test/DAO.js
+++ b/test/DAO.js
@@ -64,9 +64,9 @@ contract('LifToken DAO', function(accounts) {
 
     var transfers = [];
     for (var i = 0; i < 15; i++)
-      transfers.push(token.transfer(accounts[1], help.formatBalance(100), "", {from: accounts[2]}));
+      transfers.push(token.transfer(accounts[1], help.lif2LifWei(100), "", {from: accounts[2]}));
     for (i = 0; i < 6; i++)
-      transfers.push(token.transfer(accounts[3], help.formatBalance(10), "", {from: accounts[1]}));
+      transfers.push(token.transfer(accounts[3], help.lif2LifWei(10), "", {from: accounts[1]}));
 
     await Promise.all(transfers);
     await help.checkValues(token, accounts, 1000000, 10000000, 0, [4001440,2998500,2000060,1000000,0], [6, 4, 2, 0, 0], [6, 15, 0, 0, 0], [15, 0, 6, 0, 0]);
@@ -98,9 +98,9 @@ contract('LifToken DAO', function(accounts) {
 
     var transfers = [];
     for (var i = 0; i < 15; i++)
-      transfers.push(token.transfer(accounts[1], help.formatBalance(100), "", {from: accounts[2]}));
+      transfers.push(token.transfer(accounts[1], help.lif2LifWei(100), "", {from: accounts[2]}));
     for (i = 0; i < 6; i++)
-      transfers.push(token.transfer(accounts[3], help.formatBalance(10), "", {from: accounts[1]}));
+      transfers.push(token.transfer(accounts[3], help.lif2LifWei(10), "", {from: accounts[1]}));
 
     await Promise.all(transfers);
     await help.checkValues(token, accounts, 1000000, 10000000, 0, [4001440,2998500,2000060,1000000,0], [6, 4, 2, 0, 0], [6, 15, 0, 0, 0], [15, 0, 6, 0, 0]);
@@ -143,9 +143,9 @@ contract('LifToken DAO', function(accounts) {
 
     var transfers = [];
     for (var i = 0; i < 15; i++)
-      transfers.push(token.transfer(accounts[1], help.formatBalance(100), "", {from: accounts[2]}));
+      transfers.push(token.transfer(accounts[1], help.lif2LifWei(100), "", {from: accounts[2]}));
     for (i = 0; i < 6; i++)
-      transfers.push(token.transfer(accounts[3], help.formatBalance(10), "", {from: accounts[1]}));
+      transfers.push(token.transfer(accounts[3], help.lif2LifWei(10), "", {from: accounts[1]}));
 
     await Promise.all(transfers);
     await help.checkValues(token, accounts, 1000000, 10000000, 0, [4001440,2998500,2000060,1000000,0], [6, 4, 2, 0, 0], [6, 15, 0, 0, 0], [15, 0, 6, 0, 0]);
@@ -181,9 +181,9 @@ contract('LifToken DAO', function(accounts) {
 
     var transfers = [];
     for (var i = 0; i < 15; i++)
-      transfers.push(token.transfer(accounts[1], help.formatBalance(100), "", {from: accounts[2]}));
+      transfers.push(token.transfer(accounts[1], help.lif2LifWei(100), "", {from: accounts[2]}));
     for (i = 0; i < 6; i++)
-      transfers.push(token.transfer(accounts[3], help.formatBalance(10), "", {from: accounts[1]}));
+      transfers.push(token.transfer(accounts[3], help.lif2LifWei(10), "", {from: accounts[1]}));
     await Promise.all(transfers);
     await help.checkValues(token, accounts, 1000000, 10000000, 0, [4001440,2998500,2000060,1000000,0], [6, 4, 2, 0, 0], [6, 15, 0, 0, 0], [15, 0, 6, 0, 0]);
 
@@ -205,9 +205,9 @@ contract('LifToken DAO', function(accounts) {
 
     var transfers = [];
     for (var i = 0; i < 15; i++)
-      transfers.push(token.transfer(accounts[1], help.formatBalance(100), "", {from: accounts[2]}));
+      transfers.push(token.transfer(accounts[1], help.lif2LifWei(100), "", {from: accounts[2]}));
     for (i = 0; i < 6; i++)
-      transfers.push(token.transfer(accounts[3], help.formatBalance(10), "", {from: accounts[1]}));
+      transfers.push(token.transfer(accounts[3], help.lif2LifWei(10), "", {from: accounts[1]}));
     await Promise.all(transfers);
     await help.checkValues(token, accounts, 1000000, 10000000, 0, [4001440,2998500,2000060,1000000,0], [6, 4, 2, 0, 0], [6, 15, 0, 0, 0], [15, 0, 6, 0, 0]);
 

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -34,22 +34,22 @@ contract('LifToken', function(accounts) {
 
   it("should return the correct allowance amount after approval", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts)
-    await token.approve(accounts[2], help.formatBalance(10),{ from: accounts[1] });
+    await token.approve(accounts[2], help.lif2LifWei(10),{ from: accounts[1] });
     let allowance = await token.allowance(accounts[1], accounts[2],{ from: accounts[1]});
-    assert.equal(help.parseBalance(allowance), 10);
+    assert.equal(help.lifWei2Lif(allowance), 10);
     await help.checkValues(token, accounts,1000000, 10000000, 0, [4000000,3000000,2000000,1000000,0]);
   });
 
   it("should return correct balances after transfer", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts)
-    await token.transfer(accounts[2], help.formatBalance(33.3), { from: accounts[1] });
+    await token.transfer(accounts[2], help.lif2LifWei(33.3), { from: accounts[1] });
     await help.checkValues(token, accounts,1000000, 10000000, 0, [3999966.7,3000033.3,2000000,1000000,0]);
   });
 
   it("should throw an error when trying to transfer more than balance", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts)
     try {
-      await token.transfer(accounts[2], help.formatBalance(4000001));
+      await token.transfer(accounts[2], help.lif2LifWei(4000001));
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }
@@ -58,16 +58,16 @@ contract('LifToken', function(accounts) {
 
   it("should return correct balances after transfering from another account", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts)
-    await token.approve(accounts[3], help.formatBalance(1000), {from: accounts[1]});
-    await token.transferFrom(accounts[1], accounts[3], help.formatBalance(1000), {from: accounts[3]});
+    await token.approve(accounts[3], help.lif2LifWei(1000), {from: accounts[1]});
+    await token.transferFrom(accounts[1], accounts[3], help.lif2LifWei(1000), {from: accounts[3]});
     await help.checkValues(token, accounts,1000000, 10000000, 0, [3999000,3000000,2001000,1000000,0]);
   });
 
   it("should throw an error when trying to transfer more than allowed", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts)
-    await token.approve(accounts[3], help.formatBalance(1000), {from: accounts[1]});
+    await token.approve(accounts[3], help.lif2LifWei(1000), {from: accounts[1]});
     try {
-      await token.transferFrom(accounts[1], accounts[3], help.formatBalance(1001), {from: accounts[3]});
+      await token.transferFrom(accounts[1], accounts[3], help.lif2LifWei(1001), {from: accounts[3]});
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }
@@ -78,7 +78,7 @@ contract('LifToken', function(accounts) {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts)
 
     var dataEncoded = help.hexEncode(JSON.stringify({awesomeField:"AwesomeString"}));
-    let transaction = await token.transferData(accounts[2], help.formatBalance(1000), dataEncoded, false, {from: accounts[1]});
+    let transaction = await token.transferData(accounts[2], help.lif2LifWei(1000), dataEncoded, false, {from: accounts[1]});
     let decodedEvents = help.abiDecoder.decodeLogs(transaction.receipt.logs);
 
     assert.equal(dataEncoded, web3.toAscii(decodedEvents[0].events[3].value));
@@ -91,10 +91,10 @@ contract('LifToken', function(accounts) {
   it("should return correct balances after transferDataFrom and show the right JSON data transfered", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts);
 
-    await token.approve(accounts[3], help.formatBalance(1000), {from: accounts[1]});
+    await token.approve(accounts[3], help.lif2LifWei(1000), {from: accounts[1]});
 
     var dataEncoded = help.hexEncode(JSON.stringify({awesomeField:"AwesomeString"}));
-    let transaction = await token.transferDataFrom(accounts[1], accounts[3], help.formatBalance(1000), dataEncoded, false, {from: accounts[3]});
+    let transaction = await token.transferDataFrom(accounts[1], accounts[3], help.lif2LifWei(1000), dataEncoded, false, {from: accounts[3]});
     let decodedEvents = help.abiDecoder.decodeLogs(transaction.receipt.logs);
 
     assert.equal(dataEncoded, web3.toAscii(decodedEvents[0].events[3].value));
@@ -132,13 +132,13 @@ contract('LifToken', function(accounts) {
 
     let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
 
-    let transaction = await token.transferData(message.contract.address, help.formatBalance(1000), data, true, {from: accounts[1]});
+    let transaction = await token.transferData(message.contract.address, help.lif2LifWei(1000), data, true, {from: accounts[1]});
     let decodedEvents = help.abiDecoder.decodeLogs(transaction.receipt.logs);
 
     assert.equal(2, decodedEvents.length);
     assert.equal(data, decodedEvents[1].events[3].value);
 
-    assert.equal(help.formatBalance(1000), await token.balanceOf(message.contract.address));
+    assert.equal(help.lif2LifWei(1000), await token.balanceOf(message.contract.address));
 
     await help.checkValues(token, accounts,1000000, 10000000, 0, [3999000,3000000,2000000,1000000,0]);
   });
@@ -150,9 +150,9 @@ contract('LifToken', function(accounts) {
 
     let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
 
-    await token.approve(accounts[2], help.formatBalance(1000), {from: accounts[1]});
+    await token.approve(accounts[2], help.lif2LifWei(1000), {from: accounts[1]});
 
-    let transaction = await token.transferDataFrom(accounts[1], message.contract.address, help.formatBalance(1000), data, true, {from: accounts[2]});
+    let transaction = await token.transferDataFrom(accounts[1], message.contract.address, help.lif2LifWei(1000), data, true, {from: accounts[2]});
     let decodedEvents = help.abiDecoder.decodeLogs(transaction.receipt.logs);
 
     assert.equal(2, decodedEvents.length);
@@ -160,7 +160,7 @@ contract('LifToken', function(accounts) {
     assert.equal('0x1e24000000000000000000000000000000000000000000000000000000000000', decodedEvents[0].events[0].value);
     assert.equal(666, decodedEvents[0].events[1].value);
     assert.equal('Transfer Done', decodedEvents[0].events[2].value);
-    assert.equal(help.formatBalance(1000), await token.balanceOf(message.contract.address));
+    assert.equal(help.lif2LifWei(1000), await token.balanceOf(message.contract.address));
 
     await help.checkValues(token, accounts,1000000, 10000000, 0, [3999000,3000000,2000000,1000000,0]);
   });
@@ -172,13 +172,13 @@ contract('LifToken', function(accounts) {
 
     let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
 
-    let transaction = await token.approveData(message.contract.address, help.formatBalance(1000), data, true, {from: accounts[1]});
+    let transaction = await token.approveData(message.contract.address, help.lif2LifWei(1000), data, true, {from: accounts[1]});
     let decodedEvents = help.abiDecoder.decodeLogs(transaction.receipt.logs);
 
     assert.equal(2, decodedEvents.length);
     assert.equal(data, decodedEvents[1].events[3].value);
 
-    assert.equal(help.formatBalance(1000), await token.allowance(accounts[1], message.contract.address));
+    assert.equal(help.lif2LifWei(1000), await token.allowance(accounts[1], message.contract.address));
 
     await help.checkValues(token, accounts,1000000, 10000000, 0, [4000000,3000000,2000000,1000000,0]);
   });
@@ -187,7 +187,7 @@ contract('LifToken', function(accounts) {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts);
 
     try {
-      await token.transferData(token.contract.address, help.formatBalance(1000), web3.toHex(0), true, {from: accounts[1]});
+      await token.transferData(token.contract.address, help.lif2LifWei(1000), web3.toHex(0), true, {from: accounts[1]});
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }
@@ -198,10 +198,10 @@ contract('LifToken', function(accounts) {
   it("should fail transferDataFrom when using LifToken contract address as receiver", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts);
 
-    await token.approve(accounts[1], help.formatBalance(1000), {from: accounts[3]});
+    await token.approve(accounts[1], help.lif2LifWei(1000), {from: accounts[3]});
 
     try {
-      await token.transferDataFrom(accounts[3], token.contract.address, help.formatBalance(1000), web3.toHex(0), true, {from: accounts[1]});
+      await token.transferDataFrom(accounts[3], token.contract.address, help.lif2LifWei(1000), web3.toHex(0), true, {from: accounts[1]});
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }
@@ -213,7 +213,7 @@ contract('LifToken', function(accounts) {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts);
 
     try {
-      await token.transfer(token.contract.address, help.formatBalance(1000), {from: accounts[1]});
+      await token.transfer(token.contract.address, help.lif2LifWei(1000), {from: accounts[1]});
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }
@@ -224,10 +224,10 @@ contract('LifToken', function(accounts) {
   it("should fail transferFrom when using LifToken contract address as receiver", async function() {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts);
 
-    await token.approve(accounts[1], help.formatBalance(1000), {from: accounts[3]});
+    await token.approve(accounts[1], help.lif2LifWei(1000), {from: accounts[3]});
 
     try {
-      await token.transferFrom(accounts[3], token.contract.address, help.formatBalance(1000), {from: accounts[1]});
+      await token.transferFrom(accounts[3], token.contract.address, help.lif2LifWei(1000), {from: accounts[1]});
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }
@@ -239,7 +239,7 @@ contract('LifToken', function(accounts) {
     await help.simulateCrowdsale(token, 10000000, web3.toWei(0.1, 'ether'), [4000000,3000000,2000000,1000000,0], accounts);
 
     try {
-      await token.approve(token.contract.address, help.formatBalance(1000), {from: accounts[3]});
+      await token.approve(token.contract.address, help.lif2LifWei(1000), {from: accounts[3]});
     } catch (error) {
       if (error.message.search('invalid JUMP') == -1) throw error;
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -30,10 +30,10 @@ module.exports = {
     return back;
   },
 
-  parseBalance: function(balance){
+  lifWei2Lif: function(balance){
     return (balance/Math.pow(10,TOKEN_DECIMALS)).toPrecision(TOKEN_DECIMALS);
   },
-  formatBalance: function(balance){
+  lif2LifWei: function(balance){
     return (balance*Math.pow(10,TOKEN_DECIMALS));
   },
 
@@ -134,7 +134,7 @@ module.exports = {
         console.log(
           'Account[' + (i + 1) + ']',
           accounts[i + 1],
-          ", Balance:", this.parseBalance(tokenAccountBalances[i]),
+          ", Balance:", this.lifWei2Lif(tokenAccountBalances[i]),
           ", Votes:", parseInt(tokenAccountBalances[i]),
           ", txsSent / txsReceived:", parseInt(tokenAccountTxSent[i]), parseInt(tokenAccountTxReceived[i]));
       }
@@ -147,11 +147,11 @@ module.exports = {
     if (tokenPrice)
       assert.equal(this.toWei(crowdsalePrice), tokenPrice);
     if (balances){
-      assert.equal(this.parseBalance(tokenAccountBalances[0]), balances[0]);
-      assert.equal(this.parseBalance(tokenAccountBalances[1]), balances[1]);
-      assert.equal(this.parseBalance(tokenAccountBalances[2]), balances[2]);
-      assert.equal(this.parseBalance(tokenAccountBalances[3]), balances[3]);
-      assert.equal(this.parseBalance(tokenAccountBalances[4]), balances[4]);
+      assert.equal(this.lifWei2Lif(tokenAccountBalances[0]), balances[0]);
+      assert.equal(this.lifWei2Lif(tokenAccountBalances[1]), balances[1]);
+      assert.equal(this.lifWei2Lif(tokenAccountBalances[2]), balances[2]);
+      assert.equal(this.lifWei2Lif(tokenAccountBalances[3]), balances[3]);
+      assert.equal(this.lifWei2Lif(tokenAccountBalances[4]), balances[4]);
     }
     if (votes){
       assert.equal(parseInt(tokenAccountVotes[0]), votes[0]);


### PR DESCRIPTION
They convert from Lif units to fraction of Lif units. Same as `ethToWei`.  While working on the codebase I found it confusing to know when to use which of them.
Even though I'm just using LifWei to represent "fraction of a Lif", we should find a good name for it"

Maybe @kvakes has a name for it? I remember you mentioned something a while ago, but I'm not sure...