### PR TITLE
Compile contracts first to make use of incremental compilation

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,7 @@ if [ ! $trpc_running ]; then
   trpc_pid=$!
 fi
 
+./node_modules/truffle/cli.js compile
 ./node_modules/truffle/cli.js test $1
 test_result=$?
 


### PR DESCRIPTION
Makes running tests faster (full compilation takes 20s vs incremental compilation 3s in my laptop)