### PR TITLE
[WIP] Propery-based tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 script:
   - set -e
   - jshint --show-non-errors test/*.js || echo "Errors in jshint ignored bc it doesn't support async/await"
-  - yarn test
+  - GEN_TESTS_QTY=20 yarn test

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -213,21 +213,22 @@ contract LifCrowdsale is Ownable, PullPayment {
       if (tokensSold.add(presaleTokens).add(tokensQty) > totalTokens)
         throw;
 
-      if (weiRaised.add(weiCost) <= maxCap) {
+      if (weiRaised.add(weiCost) > maxCap)
+        throw;
 
-        if (weiChange > 0)
-          safeSend(msg.sender, weiChange);
+      //
+      // bid is accepted from here
+      //
 
-        lastPrice = tokenPrice;
-        weiPayed[msg.sender] = weiCost;
-        tokens[msg.sender] = tokensQty;
-        weiRaised = weiRaised.add(weiCost);
-        tokensSold = tokensSold.add(tokensQty);
+      // asynchronously send weiChange if any
+      if (weiChange > 0)
+        safeSend(msg.sender, weiChange);
 
-      } else {
-        safeSend(msg.sender, msg.value);
-      }
-
+      lastPrice = tokenPrice;
+      weiPayed[msg.sender] = weiCost;
+      tokens[msg.sender] = tokensQty;
+      weiRaised = weiRaised.add(weiCost);
+      tokensSold = tokensSold.add(tokensQty);
     }
 
     // See if the status of the crowdsale can be changed

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -173,7 +173,7 @@ contract LifCrowdsale is Ownable, PullPayment {
 
       uint price = 0;
 
-      if ((startBlock < block.number) && (block.number < endBlock)) {
+      if ((block.number >= startBlock) && (block.number < endBlock)) {
         price = startPrice.sub(
           block.number.sub(startBlock).div(changePerBlock).mul(changePrice)
         );

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -173,7 +173,7 @@ contract LifCrowdsale is Ownable, PullPayment {
 
       uint price = 0;
 
-      if ((block.number >= startBlock) && (block.number < endBlock)) {
+      if ((block.number >= startBlock) && (block.number <= endBlock)) {
         price = startPrice.sub(
           block.number.sub(startBlock).div(changePerBlock).mul(changePrice)
         );

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -199,7 +199,7 @@ contract LifCrowdsale is Ownable, PullPayment {
 
       uint tokenPrice = getPrice();
 
-      if (tokenPrice == 0)
+      if ((tokenPrice == 0) || (msg.value == 0))
         throw;
 
       // Calculate the total cost in wei of buying the tokens.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "abi-decoder": "^1.0.8",
     "ethereumjs-abi": "^0.6.4",
+    "jsverify": "^0.8.2",
     "lodash": "^4.17.4",
     "protobufjs": "^6.0.2",
     "solc": "^0.4.9",

--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -65,7 +65,7 @@ contract('LifToken Crowdsale', function(accounts) {
   });
 
   it("Should simulate a crowdsale of 7m tokens, no owner payment, with one dutch auction and just 1 bidder", async function() {
-    var startBlock = web3.eth.blockNumber+5;
+    var startBlock = web3.eth.blockNumber+7;
     var endBlock = startBlock+5;
     var totalWeiSent = 0;
     var totalTokensBought = 0;
@@ -105,7 +105,7 @@ contract('LifToken Crowdsale', function(accounts) {
     var price = parseFloat(await crowdsale.getPrice());
     assert.equal(price, web3.toWei(0, 'ether'));
 
-    await help.waitToBlock(startBlock+1, accounts);
+    await help.waitToBlock(startBlock, accounts);
 
     // Submit bid of 500000 on accounts[1]
     price = parseFloat(await crowdsale.getPrice());

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -28,29 +28,6 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     done();
   });
 
-  let getExpectedPrice = function(startBlock, endBlock, crowdsaleData) {
-    if (web3.eth.blockNumber < startBlock || web3.eth.blockNumber > endBlock) {
-      return 0;
-    } else if (crowdsaleData.changePerBlock == 0) {
-      return -1; // this should throw anyways
-    } else {
-      let blocksCount = ((web3.eth.blockNumber > endBlock) ? endBlock : web3.eth.blockNumber) - startBlock;
-      help.debug("price data: ", crowdsaleData.startPrice, blocksCount, crowdsaleData.changePrice, crowdsaleData.changePerBlock);
-      return crowdsaleData.startPrice - (blocksCount * crowdsaleData.changePrice / crowdsaleData.changePerBlock);
-    }
-  }
-
-  let shouldGetPriceThrow = function(startBlock, endBlock, crowdsaleData) {
-    if (web3.eth.blockNumber < startBlock) {
-      return false;
-    } else if (crowdsaleData.changePerBlock == 0) {
-      return true;
-    } else {
-      let blocksCount = ((web3.eth.blockNumber > endBlock) ? endBlock : web3.eth.blockNumber) - startBlock;
-      return crowdsaleData.startPrice < (blocksCount * crowdsaleData.changePrice / crowdsaleData.changePerBlock);
-    }
-  }
-
   it("distributes tokens correctly on any combination of bids", async function() {
     /*
     var weiGen = jsc.nat.generator.map(function(x) {
@@ -117,12 +94,12 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         help.debug("block before getPrice:", web3.eth.blockNumber);
         price = parseFloat(await crowdsale.getPrice());
         help.debug("block after getPrice:", web3.eth.blockNumber);
-        assert.equal(false, shouldGetPriceThrow(startBlock, endBlock, crowdsaleData),
+        assert.equal(false, help.shouldCrowdsaleGetPriceThrow(startBlock, endBlock, crowdsaleData),
           "getPrice should have thrown because crowdsale config makes the price go negative");
 
         if (price != 0) {
           // all of this is because there is a small rounding difference sometimes.
-          let priceDiffPercent = (getExpectedPrice(startBlock, endBlock, crowdsaleData) - price) / price;
+          let priceDiffPercent = (help.getCrowdsaleExpectedPrice(startBlock, endBlock, crowdsaleData) - price) / price;
           let maxPriceDiff = 0.000000001;
           help.debug("price:", price, "price diff: ", priceDiffPercent);
           assert.equal(true, Math.abs(priceDiffPercent) <= maxPriceDiff, "price diff should be less than " + maxPriceDiff + " but it's " + priceDiffPercent);
@@ -130,10 +107,10 @@ contract('LifCrowdsale Property-based test', function(accounts) {
           assert.equal(0, price);
       }
       catch (e) {
-        help.debug("estimatedPrice:", getExpectedPrice(startBlock, endBlock, crowdsaleData),
-          "shouldGetPriceThrow: ", shouldGetPriceThrow(startBlock, endBlock, crowdsaleData),
+        help.debug("estimatedPrice:", help.getCrowdsaleExpectedPrice(startBlock, endBlock, crowdsaleData),
+          "shouldGetPriceThrow: ", help.shouldCrowdsaleGetPriceThrow(startBlock, endBlock, crowdsaleData),
           "error: ", e);
-        assert.equal(true, shouldGetPriceThrow(startBlock, endBlock, crowdsaleData), "we didn't expect getPrice to throw but it did...");
+        assert.equal(true, help.shouldCrowdsaleGetPriceThrow(startBlock, endBlock, crowdsaleData), "we didn't expect getPrice to throw but it did...");
 
         help.debug("the crowdsale params are invalid but the test catched that fine. Stopping here");
         return true;

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -204,7 +204,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         let shouldThrow = shouldCommandThrow(command, state);
         try {
           state = await runCommand(command, state);
-          assert.equal(false, shouldThrow, "command " + command + " should have thrown but it didn't.\nCommand: " + JSON.stringify(command) + "\nState: " + state);
+          assert.equal(false, shouldThrow, "command " + JSON.stringify(command) + " should have thrown but it didn't.\nState: " + state);
         }
         catch(error) {
           help.debug("An error occurred, block number: " + web3.eth.blockNumber);

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -1,0 +1,148 @@
+var protobuf = require("protobufjs");
+var _ = require('lodash');
+var jsc = require("jsverify");
+
+var help = require("./helpers");
+
+var LifToken = artifacts.require("./LifToken.sol");
+var LifCrowdsale = artifacts.require("./LifCrowdsale.sol");
+var FuturePayment = artifacts.require("./FuturePayment.sol");
+
+const LOG_EVENTS = true;
+
+contract('LifCrowdsale Property-based test', function(accounts) {
+  var token;
+  var eventsWatcher;
+
+  beforeEach(async function() {
+    token = await LifToken.new(web3.toWei(10, 'ether'), 10000, 2, 3, 5, {from: accounts[0]});
+    eventsWatcher = token.allEvents();
+    eventsWatcher.watch(function(error, log){
+      if (LOG_EVENTS)
+        console.log('Event:', log.event, ':',log.args);
+    });
+  });
+
+  afterEach(function(done) {
+    eventsWatcher.stopWatching();
+    done();
+  });
+
+  let getExpectedPrice = function(startBlock, endBlock, crowdsaleData) {
+    if (web3.eth.blockNumber < startBlock || web3.eth.blockNumber > endBlock) {
+      return 0;
+    } else if (crowdsaleData.changePerBlock == 0) {
+      return -1; // this should throw anyways
+    } else {
+      let blocksCount = ((web3.eth.blockNumber > endBlock) ? endBlock : web3.eth.blockNumber) - startBlock;
+      help.debug("price data: ", crowdsaleData.startPrice, blocksCount, crowdsaleData.changePrice, crowdsaleData.changePerBlock);
+      return crowdsaleData.startPrice - (blocksCount * crowdsaleData.changePrice / crowdsaleData.changePerBlock);
+    }
+  }
+
+  let shouldGetPriceThrow = function(startBlock, endBlock, crowdsaleData) {
+    if (web3.eth.blockNumber < startBlock) {
+      return false;
+    } else if (crowdsaleData.changePerBlock == 0) {
+      return true;
+    } else {
+      let blocksCount = ((web3.eth.blockNumber > endBlock) ? endBlock : web3.eth.blockNumber) - startBlock;
+      return crowdsaleData.startPrice < (blocksCount * crowdsaleData.changePrice / crowdsaleData.changePerBlock);
+    }
+  }
+
+  it("distributes tokens correctly on any combination of bids", async function() {
+    /*
+    var weiGen = jsc.nat.generator.map(function(x) {
+      return web3.toWei(x, 'ether');
+    });
+    */
+
+    let crowdsaleRawGen = jsc.record({
+      startPriceEth: jsc.nat,
+      changePerBlock: jsc.nat,
+      changePriceEth: jsc.nat,
+      minCapEth: jsc.nat,
+      maxCapEth: jsc.nat,
+      maxTokens: jsc.nat,
+      presaleBonusRate: jsc.nat,
+      ownerPercentage: jsc.nat
+    });
+
+    let crowdsaleGen = jsc.suchthat(crowdsaleRawGen, function(c) {
+      return c.maxCap >= c.minCap &&
+        c.changePerBlock > 0;
+    });
+
+    let bidsGen = jsc.array(jsc.nat);
+
+    let crowdsaleTestInputGen = jsc.record({
+      crowdsale: crowdsaleRawGen,
+      bids: bidsGen
+    });
+
+    let property = jsc.forall(crowdsaleTestInputGen, async function(input) {
+      let blocksCount = 5;
+      let startBlock = web3.eth.blockNumber + 5;
+      let endBlock = startBlock + blocksCount;
+
+      help.debug("crowdsaleTestInput data:\n", input, startBlock, endBlock);
+
+      let crowdsaleData = {
+        token: token,
+        startBlock: startBlock, endBlock: endBlock,
+        startPrice: web3.toWei(input.crowdsale.startPriceEth, 'ether'),
+        changePerBlock: input.crowdsale.changePerBlock, changePrice: web3.toWei(input.crowdsale.changePriceEth, 'ether'),
+        minCap: web3.toWei(input.crowdsale.minCapEth, 'ether'), maxCap: web3.toWei(input.crowdsale.maxCapEth, 'ether'),
+        maxTokens: input.crowdsale.maxTokens,
+        presaleBonusRate: input.crowdsale.presaleBonusRate, ownerPercentage: input.crowdsale.ownerPercentage
+      };
+
+      let crowdsale = await help.createCrowdsale(crowdsaleData, accounts);
+
+      help.debug("created crowdsale at address ", crowdsale.address);
+
+      // Assert price == 0 before start
+      let price = parseFloat(await crowdsale.getPrice());
+      assert.equal(price, web3.toWei(0, 'ether'));
+
+      await help.fundCrowdsale(crowdsaleData, crowdsale, accounts);
+
+      // wait to crowdsale start
+      await help.waitToBlock(startBlock, accounts);
+
+      help.debug("fetching new price");
+
+      try {
+        help.debug("block before getPrice:", web3.eth.blockNumber);
+        price = parseFloat(await crowdsale.getPrice());
+        help.debug("block after getPrice:", web3.eth.blockNumber);
+        assert.equal(false, shouldGetPriceThrow(startBlock, endBlock, crowdsaleData),
+          "getPrice should have thrown because crowdsale config makes the price go negative");
+
+        if (price != 0) {
+          // all of this is because there is a small rounding difference sometimes.
+          let priceDiffPercent = (getExpectedPrice(startBlock, endBlock, crowdsaleData) - price) / price;
+          let maxPriceDiff = 0.000000001;
+          help.debug("price:", price, "price diff: ", priceDiffPercent);
+          assert.equal(true, Math.abs(priceDiffPercent) <= maxPriceDiff, "price diff should be less than " + maxPriceDiff + " but it's " + priceDiffPercent);
+        } else
+          assert.equal(0, price);
+      }
+      catch (e) {
+        help.debug("estimatedPrice:", getExpectedPrice(startBlock, endBlock, crowdsaleData),
+          "shouldGetPriceThrow: ", shouldGetPriceThrow(startBlock, endBlock, crowdsaleData),
+          "error: ", e);
+        assert.equal(true, shouldGetPriceThrow(startBlock, endBlock, crowdsaleData), "we didn't expect getPrice to throw but it did...");
+
+        help.debug("the crowdsale params are invalid but the test catched that fine. Stopping here");
+        return true;
+      }
+
+      return true;
+    });
+
+    return jsc.assert(property, {tests: 10, size: 10});
+  });
+
+});

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -1,6 +1,7 @@
 var protobuf = require("protobufjs");
 var _ = require('lodash');
 var jsc = require("jsverify");
+var chai = require("chai");
 
 var help = require("./helpers");
 
@@ -28,124 +29,177 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     done();
   });
 
-  it("distributes tokens correctly on any combination of bids", async function() {
-    let crowdsaleRawGen = jsc.record({
-      startPriceEth: jsc.nat,
-      changePerBlock: jsc.nat,
-      changePriceEth: jsc.nat,
-      minCapEth: jsc.nat,
-      maxCapEth: jsc.nat,
-      maxTokens: jsc.nat,
-      presaleBonusRate: jsc.nat,
-      ownerPercentage: jsc.nat
-    });
+  let crowdsaleRawGen = jsc.record({
+    startPriceEth: jsc.nat,
+    changePerBlock: jsc.nat,
+    changePriceEth: jsc.nonshrink(jsc.nat),
+    minCapEth: jsc.nat,
+    maxCapEth: jsc.nat,
+    maxTokens: jsc.nat,
+    presaleBonusRate: jsc.nonshrink(jsc.nat),
+    ownerPercentage: jsc.nonshrink(jsc.nat)
+  });
 
-    let crowdsaleGen = jsc.suchthat(crowdsaleRawGen, function(c) {
-      return (c.maxCapEth >= c.minCapEth) &&
-        (c.changePerBlock > 0);
-    });
+  let crowdsaleGen = jsc.suchthat(crowdsaleRawGen, function(c) {
+    return (c.maxCapEth >= c.minCapEth) &&
+      (c.changePerBlock > 0);
+  });
 
-    let waitBlockCommandGen = jsc.record({
-      type: jsc.constant("waitBlock")
-    });
-    let checkPriceCommandGen = jsc.record({
-      type: jsc.constant("checkPrice")
-    });
+  let waitBlockCommandGen = jsc.record({
+    type: jsc.constant("waitBlock")
+  });
+  let checkPriceCommandGen = jsc.record({
+    type: jsc.constant("checkPrice")
+  });
+  let submitBidCommandGen = jsc.record({
+    type: jsc.constant("submitBid"),
+    account: jsc.elements(accounts),
+    tokens: jsc.nat
+  });
+  let setStatusCommandGen = jsc.record({
+    type: jsc.constant("setStatus"),
+    status: jsc.elements([1,2,3])
+  });
 
-    let commandsGen = jsc.oneof([waitBlockCommandGen, checkPriceCommandGen]);
+  let commandsGen = jsc.nonshrink(jsc.oneof([
+    waitBlockCommandGen,
+    checkPriceCommandGen,
+    submitBidCommandGen,
+    setStatusCommandGen
+  ]));
 
-    let crowdsaleTestInputGen = jsc.record({
-      crowdsale: crowdsaleGen,
-      commands: jsc.array(commandsGen)
-    });
+  let crowdsaleTestInputGen = jsc.record({
+    commands: jsc.array(commandsGen),
+    crowdsale: jsc.nonshrink(crowdsaleGen)
+  });
 
-    let shouldCommandThrow = function(command, state) {
-      if (command.type == "waitBlock") {
-        return false;
-      } else if (command.type = "checkPrice") {
-        let crowdsale = state.crowdsaleData;
-        let { startBlock, endBlock } = crowdsale;
-        return help.shouldCrowdsaleGetPriceThrow(startBlock, endBlock, crowdsale);
-      }
+  let shouldCommandThrow = function(command, state) {
+    if (command.type == "waitBlock") {
+      return false;
+    } else if (command.type == "checkPrice") {
+      let crowdsale = state.crowdsaleData;
+      let { startBlock, endBlock } = crowdsale;
+      return help.shouldCrowdsaleGetPriceThrow(startBlock, endBlock, crowdsale);
+    } else if (command.type == "submitBid") {
+      let crowdsale = state.crowdsaleData;
+      let { startBlock, endBlock } = crowdsale;
+      let price = help.getCrowdsaleExpectedPrice(startBlock, endBlock, crowdsale);
+      let soldTokens = _.sumBy(state.bids || [], (b) => b.tokens);
+
+      return (web3.eth.blockNumber < crowdsale.startBlock) ||
+        (web3.eth.blockNumber > crowdsale.endBlock) ||
+        (state.status != 2) ||
+        (command.tokens == 0) ||
+        (price == 0) ||
+        (soldTokens + command.tokens > crowdsale.maxTokens);
+    } else if (command.type == "setStatus") {
+      return false;
+    } else {
+      assert(false, "unknnow command " + command.type);
     }
+  }
 
-    let runCommand = async function(command, state) {
-      if (command.type == "waitBlock") {
-        await help.waitBlocks(1, accounts);
-        return state;
-      } else if (command.type == "checkPrice") {
-        let expectedPrice = help.getCrowdsaleExpectedPrice(
-          state.crowdsaleData.startBlock, state.crowdsaleData.endBlock, state.crowdsaleData
-        );
-        let price = parseFloat(await state.crowdsaleContract.getPrice());
+  let runCommand = async function(command, state) {
+    if (command.type == "waitBlock") {
+      await help.waitBlocks(1, accounts);
+      return state;
+    } else if (command.type == "checkPrice") {
+      let expectedPrice = help.getCrowdsaleExpectedPrice(
+        state.crowdsaleData.startBlock, state.crowdsaleData.endBlock, state.crowdsaleData
+      );
+      let price = parseFloat(await state.crowdsaleContract.getPrice());
 
-        if (price != 0) {
-          // all of this is because there is a small rounding difference sometimes.
-          let priceDiffPercent = (expectedPrice - price) / price;
-          help.debug("price", price, " expected price: ", expectedPrice, " diff %: ", priceDiffPercent);
-          let maxPriceDiff = 0.000000001;
-          assert.equal(true, Math.abs(priceDiffPercent) <= maxPriceDiff,
-            "price diff should be less than " + maxPriceDiff + " but it's " + priceDiffPercent);
+      if (price != 0) {
+        // all of this is because there is a small rounding difference sometimes.
+        let priceDiffPercent = (expectedPrice - price) / price;
+        help.debug("price", price, " expected price: ", expectedPrice, " diff %: ", priceDiffPercent);
+        let maxPriceDiff = 0.000000001;
+        assert.equal(true, Math.abs(priceDiffPercent) <= maxPriceDiff,
+          "price diff should be less than " + maxPriceDiff + " but it's " + priceDiffPercent);
+      }  else {
+        assert.equal(expectedPrice, price,
+          "expected price is different! Expected: " + expectedPrice + ", actual: " + price + ". blocks: " + web3.eth.blockNumber + ", start/end: " +
+          state.crowdsaleData.startBlock + "/" + state.crowdsaleData.endBlock);
+      }
+
+      return state;
+    } else if (command.type == "submitBid") {
+      let price = help.getCrowdsaleExpectedPrice(
+        state.crowdsaleData.startBlock, state.crowdsaleData.endBlock, state.crowdsaleData
+      );
+      help.debug("submitBid price:", price, "blockNumber:", web3.eth.blockNumber);
+      await state.crowdsaleContract.submitBid({
+        value: price * command.tokens,
+        from: command.account
+      });
+      state.bids = _.concat(state.bids || [], {tokens: command.tokens, price: price, account: command.account});
+      return state;
+    } else if (command.type == "setStatus") {
+      await state.crowdsaleContract.setStatus(command.status, {from: accounts[0]});
+      state.status = command.status;
+      return state;
+    } else {
+      throw("Unknown command type " + command.type);
+    }
+  }
+
+  let runGeneratedCrowdsaleAndCommands = async function(input) {
+    let blocksCount = 5;
+    let startBlock = web3.eth.blockNumber + 5;
+    let endBlock = startBlock + blocksCount;
+
+    help.debug("crowdsaleTestInput data:\n", input, startBlock, endBlock);
+
+    let crowdsaleData = {
+      token: token,
+      startBlock: startBlock, endBlock: endBlock,
+      startPrice: web3.toWei(input.crowdsale.startPriceEth, 'ether'),
+      changePerBlock: input.crowdsale.changePerBlock, changePrice: web3.toWei(input.crowdsale.changePriceEth, 'ether'),
+      minCap: web3.toWei(input.crowdsale.minCapEth, 'ether'), maxCap: web3.toWei(input.crowdsale.maxCapEth, 'ether'),
+      maxTokens: input.crowdsale.maxTokens,
+      presaleBonusRate: input.crowdsale.presaleBonusRate, ownerPercentage: input.crowdsale.ownerPercentage
+    };
+
+    let crowdsale = await help.createCrowdsale(crowdsaleData, accounts);
+
+    help.debug("created crowdsale at address ", crowdsale.address);
+
+    // Assert price == 0 before start
+    let price = parseFloat(await crowdsale.getPrice());
+    assert.equal(price, web3.toWei(0, 'ether'));
+
+    await help.fundCrowdsale(crowdsaleData, crowdsale, accounts);
+
+    var state = {
+      crowdsaleData: crowdsaleData,
+      crowdsaleContract: crowdsale,
+      status: 1 // crowdsale status
+    };
+
+    for (let command of input.commands) {
+      let shouldThrow = shouldCommandThrow(command, state);
+      try {
+        state = await runCommand(command, state);
+        assert.equal(false, shouldThrow, "command " + command + " should have thrown but it didn't.\nState: " + state);
+      }
+      catch(error) {
+        if (error instanceof chai.AssertionError) {
+          throw(error);
         } else {
-          assert.equal(expectedPrice, price,
-            "expected price is different! Expected: " + expectedPrice + ", actual: " + price + ". blocks: " + web3.eth.blockNumber + ", start/end: " + 
-            state.crowdsaleData.startBlock + "/" + state.crowdsaleData.endBlock);
+          assert.equal(true, shouldThrow, "command " + command + " should not have thrown but it did.\nError: " + error + "\nState: " + state);
         }
-
-        return state;
-      } else {
-        throw("Unknown command type " + command.type);
       }
     }
 
-    let property = jsc.forall(crowdsaleTestInputGen, async function(input) {
-      let blocksCount = 5;
-      let startBlock = web3.eth.blockNumber + 5;
-      let endBlock = startBlock + blocksCount;
+    return true;
+  }
 
-      help.debug("crowdsaleTestInput data:\n", input, startBlock, endBlock);
+  it("distributes tokens correctly on any combination of bids", async function() {
+    // stateful prob based tests can take a long time to finish when shrinking...
+    this.timeout(120 * 1000);
 
-      let crowdsaleData = {
-        token: token,
-        startBlock: startBlock, endBlock: endBlock,
-        startPrice: web3.toWei(input.crowdsale.startPriceEth, 'ether'),
-        changePerBlock: input.crowdsale.changePerBlock, changePrice: web3.toWei(input.crowdsale.changePriceEth, 'ether'),
-        minCap: web3.toWei(input.crowdsale.minCapEth, 'ether'), maxCap: web3.toWei(input.crowdsale.maxCapEth, 'ether'),
-        maxTokens: input.crowdsale.maxTokens,
-        presaleBonusRate: input.crowdsale.presaleBonusRate, ownerPercentage: input.crowdsale.ownerPercentage
-      };
-
-      let crowdsale = await help.createCrowdsale(crowdsaleData, accounts);
-
-      help.debug("created crowdsale at address ", crowdsale.address);
-
-      // Assert price == 0 before start
-      let price = parseFloat(await crowdsale.getPrice());
-      assert.equal(price, web3.toWei(0, 'ether'));
-
-      await help.fundCrowdsale(crowdsaleData, crowdsale, accounts);
-
-      var state = {
-        crowdsaleData: crowdsaleData,
-        crowdsaleContract: crowdsale
-      };
-
-      for (let command of input.commands) {
-        let shouldThrow = shouldCommandThrow(command, state);
-        try {
-          state = await runCommand(command, state);
-          assert.equal(false, shouldThrow, "command " + command + " should have thrown but it didn't.\nState: " + state);
-        }
-        catch(error) {
-          if (e instanceof AssertionError) {
-            throw(e);
-          } else {
-            assert.equal(true, shouldThrow, "command " + command + " should not have thrown but it did.\nError: " + error + "\nState: " + state);
-          }
-        }
-      }
-
-      return true;
+    let property = jsc.forall(crowdsaleTestInputGen, async function(crowdsaleAndCommands) {
+      return await runGeneratedCrowdsaleAndCommands(crowdsaleAndCommands);
     });
 
     return jsc.assert(property, {tests: 20});

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -194,6 +194,25 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     return true;
   }
 
+  it("should consider endBlock part of the crowdsale", async function() {
+    // this case found by the generative test, it was a bug on the getPrice function
+    // added here to avoid future regressions
+    let crowdsaleAndCommands = {
+      commands: [
+        {"type":"waitBlock"}, {"type":"waitBlock"}, {"type":"waitBlock"},
+        {"type":"setStatus","status":3},
+        {"type":"checkPrice"}
+      ],
+      crowdsale: {
+        startPriceEth: 16, changePerBlock: 37, changePriceEth: 45,
+        minCapEth: 23, maxCapEth: 32, maxTokens: 40,
+        presaleBonusRate: 23, ownerPercentage: 27
+      }
+    };
+
+    await runGeneratedCrowdsaleAndCommands(crowdsaleAndCommands);
+  });
+
   it("distributes tokens correctly on any combination of bids", async function() {
     // stateful prob based tests can take a long time to finish when shrinking...
     this.timeout(120 * 1000);

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -29,12 +29,6 @@ contract('LifCrowdsale Property-based test', function(accounts) {
   });
 
   it("distributes tokens correctly on any combination of bids", async function() {
-    /*
-    var weiGen = jsc.nat.generator.map(function(x) {
-      return web3.toWei(x, 'ether');
-    });
-    */
-
     let crowdsaleRawGen = jsc.record({
       startPriceEth: jsc.nat,
       changePerBlock: jsc.nat,
@@ -47,14 +41,14 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     });
 
     let crowdsaleGen = jsc.suchthat(crowdsaleRawGen, function(c) {
-      return c.maxCap >= c.minCap &&
-        c.changePerBlock > 0;
+      return (c.maxCapEth >= c.minCapEth) &&
+        (c.changePerBlock > 0);
     });
 
     let bidsGen = jsc.array(jsc.nat);
 
     let crowdsaleTestInputGen = jsc.record({
-      crowdsale: crowdsaleRawGen,
+      crowdsale: crowdsaleGen,
       bids: bidsGen
     });
 

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -215,6 +215,10 @@ contract('LifCrowdsale Property-based test', function(accounts) {
           }
         }
       }
+
+      // check resulting in-memory and contract state
+      assert.equal(state.status, parseInt(await crowdsale.status.call()));
+
     } finally {
       eventsWatcher.stopWatching();
     }

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -222,6 +222,22 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     return true;
   }
 
+  it("should throw when submitBid is for 0 tokens", async function() {
+    let crowdsaleAndCommands = {
+      commands: [
+        {"type":"setStatus","status":2,"fromAccount":0},
+        {"type":"submitBid","account":7,"tokens":0}
+      ],
+      crowdsale: {
+        startPriceEth: 3, changePerBlock: 1, changePriceEth: 0,
+        minCapEth: 20, maxCapEth: 33, maxTokens: 16,
+        presaleBonusRate: 32, ownerPercentage: 0
+      }
+    };
+
+    await runGeneratedCrowdsaleAndCommands(crowdsaleAndCommands);
+  });
+
   it("should raise when sum of bids exceed total tokens to be sold", async function() {
 
     let crowdsaleAndCommands = {

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -11,6 +11,10 @@ var FuturePayment = artifacts.require("./FuturePayment.sol");
 
 const LOG_EVENTS = true;
 
+let GEN_TESTS_QTY = parseInt(process.env.GEN_TESTS_QTY);
+if (isNaN(GEN_TESTS_QTY))
+  GEN_TESTS_QTY = 50;
+
 contract('LifCrowdsale Property-based test', function(accounts) {
   var token;
   var eventsWatcher;
@@ -231,13 +235,14 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
   it("distributes tokens correctly on any combination of bids", async function() {
     // stateful prob based tests can take a long time to finish when shrinking...
-    this.timeout(120 * 1000);
+    this.timeout(240 * 1000);
 
     let property = jsc.forall(crowdsaleTestInputGen, async function(crowdsaleAndCommands) {
       return await runGeneratedCrowdsaleAndCommands(crowdsaleAndCommands);
     });
 
-    return jsc.assert(property, {tests: 20});
+    console.log("Generative tests to run:", GEN_TESTS_QTY);
+    return jsc.assert(property, {tests: GEN_TESTS_QTY});
   });
 
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -197,10 +197,13 @@ module.exports = {
     console.log('['+parsedProposal.id+'] To: '+parsedProposal.target+', Value: '+parsedProposal.value +', MaxBlock: '+parsedProposal.maxBlock+', Desc: '+parsedProposal.description+', Status: '+parsedProposal.status, ', Votes: ',parsedProposal.totalVotes,'/',parsedProposal.votesNeeded);
   },
 
-  createAndFundCrowdsale: async function(params, accounts) {
+  createCrowdsale: async function(params) {
+    return await LifCrowdsale.new(params.token.address, params.startBlock, params.endBlock, params.startPrice, params.changePerBlock,
+      params.changePrice, params.minCap, params.maxCap, params.maxTokens, params.presaleBonusRate, params.ownerPercentage)
+  },
+
+  fundCrowdsale: async function(params, crowdsale, accounts) {
     let token = params.token;
-    var crowdsale = await LifCrowdsale.new(token.address, params.startBlock, params.endBlock, params.startPrice, params.changePerBlock,
-      params.changePrice, params.minCap, params.maxCap, params.maxTokens, params.presaleBonusRate, params.ownerPercentage);
 
     let oldTokenBalance = parseFloat(await token.balanceOf(token.contract.address));
 
@@ -219,6 +222,14 @@ module.exports = {
     assert.equal(parseFloat(await crowdsale.changePerBlock()), params.changePerBlock);
     assert.equal(parseFloat(await crowdsale.changePrice()), params.changePrice);
     assert.equal(parseFloat(await crowdsale.minCap()), params.minCap);
+  },
+
+  createAndFundCrowdsale: async function(params, accounts) {
+    let self = this;
+    let token = params.token;
+    var crowdsale = await self.createCrowdsale(params);
+
+    await self.fundCrowdsale(params, crowdsale, accounts);
 
     return crowdsale;
   },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -270,5 +270,21 @@ module.exports = {
       await crowdsale.distributeTokens(accounts[5], false);
     await crowdsale.transferVotes();
     return crowdsale;
+  },
+
+  getCrowdsaleExpectedPrice: function(startBlock, endBlock, crowdsale) {
+    if (web3.eth.blockNumber < startBlock || web3.eth.blockNumber > endBlock) {
+      return 0;
+    } else if (crowdsale.changePerBlock == 0) {
+      return -1; // this should throw anyways
+    } else {
+      let blocksCount = ((web3.eth.blockNumber > endBlock) ? endBlock : web3.eth.blockNumber) - startBlock;
+      this.debug("price data: ", crowdsale.startPrice, blocksCount, crowdsale.changePrice, crowdsale.changePerBlock);
+      return crowdsale.startPrice - (blocksCount * crowdsale.changePrice / crowdsale.changePerBlock);
+    }
+  },
+
+  shouldCrowdsaleGetPriceThrow: function(startBlock, endBlock, crowdsaleData) {
+    return this.getCrowdsaleExpectedPrice(startBlock, endBlock, crowdsaleData) < 0;
   }
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -280,7 +280,7 @@ module.exports = {
     } else {
       let blocksCount = ((web3.eth.blockNumber > endBlock) ? endBlock : web3.eth.blockNumber) - startBlock;
       this.debug("price data: ", crowdsale.startPrice, blocksCount, crowdsale.changePrice, crowdsale.changePerBlock);
-      return crowdsale.startPrice - (blocksCount * crowdsale.changePrice / crowdsale.changePerBlock);
+      return crowdsale.startPrice - Math.floor(blocksCount / crowdsale.changePerBlock) * crowdsale.changePrice;
     }
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,13 +799,17 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
+bignumber.js@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.2.tgz#2d1dc37ee5968867ecea90b6da4d16e68608d21d"
+
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
+  version "2.0.7"
+  resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
+
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
-  version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
 bignumber.js@~2.1.4:
   version "2.1.4"
@@ -3165,6 +3169,15 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jsverify@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/jsverify/-/jsverify-0.8.2.tgz#9c7daa72cc1b1542cc8a53af78b42ef5f5293a38"
+  dependencies:
+    lazy-seq "^1.0.0"
+    rc4 "~0.1.5"
+    trampa "^1.0.0"
+    typify-parser "^1.1.0"
+
 keccak@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.3.0.tgz#3681bd99ad3d0354ddb29b9040c1b6560cce08ac"
@@ -3217,6 +3230,10 @@ lazy-cache@^1.0.3:
 lazy-req@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
+
+lazy-seq@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazy-seq/-/lazy-seq-1.0.0.tgz#880cb8aab256026382e02f53ec089682a74c5b6a"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -4164,6 +4181,10 @@ options@>=0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
 
+original-require@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/original-require/-/original-require-1.0.1.tgz#0f130471584cd33511c5ec38c8d59213f9ac5e20"
+
 os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
@@ -4698,6 +4719,10 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+rc4@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/rc4/-/rc4-0.1.5.tgz#08c6e04a0168f6eb621c22ab6cb1151bd9f4a64d"
+
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
@@ -5191,6 +5216,16 @@ socket.io@^1.4.6:
     socket.io-client "1.7.4"
     socket.io-parser "2.3.1"
 
+solc@0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.13.tgz#aa5cbdcce3e6ae3c190d20f5fdf8bc880702ec75"
+  dependencies:
+    fs-extra "^0.30.0"
+    memorystream "^0.3.1"
+    require-from-string "^1.1.0"
+    semver "^5.3.0"
+    yargs "^4.7.1"
+
 solc@0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.6.tgz#afa929a1ceafc0252cfbb4217c8e2b1dab139db7"
@@ -5198,16 +5233,6 @@ solc@0.4.6:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"
     require-from-string "^1.1.0"
-    yargs "^4.7.1"
-
-solc@0.4.8:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.8.tgz#96abbee1266341ae97fb4bdc3abcc9bc1b5052ab"
-  dependencies:
-    fs-extra "^0.30.0"
-    memorystream "^0.3.1"
-    require-from-string "^1.1.0"
-    semver "^5.3.0"
     yargs "^4.7.1"
 
 solc@^0.4.2, solc@^0.4.9:
@@ -5593,6 +5618,10 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+trampa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trampa/-/trampa-1.0.0.tgz#5247347ac334807fa6c0000444cb91b639840ad5"
+
 traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
@@ -5621,19 +5650,19 @@ truffle-blockchain-utils@0.0.1:
   dependencies:
     web3 "^0.18.0"
 
-truffle-compile@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/truffle-compile/-/truffle-compile-1.1.2.tgz#d2e2e6b8cc52fc49447405f930c0d8346ea85db8"
+truffle-compile@~2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/truffle-compile/-/truffle-compile-2.0.4.tgz#0b132a81244f30358b687560cb6d70f62056f3e8"
   dependencies:
     async "^2.1.4"
     colors "^1.1.2"
     graphlib "^2.1.1"
-    solc "0.4.8"
+    solc "0.4.13"
     solidity-parser "^0.3.0"
-    truffle-config "0.0.7"
+    truffle-config "^1.0.1"
     truffle-contract-sources "^0.0.1"
-    truffle-error "0.0.2"
-    truffle-expect "0.0.3"
+    truffle-error "^0.0.2"
+    truffle-expect "^0.0.3"
 
 truffle-config@0.0.6:
   version "0.0.6"
@@ -5654,6 +5683,16 @@ truffle-config@0.0.7, truffle-config@~0.0.7:
     require-nocache "^1.0.0"
     truffle-error "0.0.2"
     truffle-provider "0.0.1"
+
+truffle-config@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/truffle-config/-/truffle-config-1.0.1.tgz#95b33dc5e984491e717cfcbafaa03db659272277"
+  dependencies:
+    find-up "^2.1.0"
+    lodash "^4.17.4"
+    original-require "^1.0.0"
+    truffle-error "^0.0.2"
+    truffle-provider "^0.0.2"
 
 truffle-contract-schema@0.0.5:
   version "0.0.5"
@@ -5696,7 +5735,7 @@ truffle-error@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.1.tgz#4b39badf54805a206e95fca72becabcec2c05a6f"
 
-truffle-error@0.0.2, truffle-error@~0.0.2:
+truffle-error@0.0.2, truffle-error@^0.0.2, truffle-error@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.2.tgz#01b189b78505566ae1689c239c7ca2dd121cfe4c"
 
@@ -5741,6 +5780,13 @@ truffle-provider@0.0.1, truffle-provider@~0.0.1:
   dependencies:
     web3 "^0.18.0"
 
+truffle-provider@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/truffle-provider/-/truffle-provider-0.0.2.tgz#52614dc04bdaf878f64392b387e6432f9c9bcc6f"
+  dependencies:
+    truffle-error "^0.0.2"
+    web3 "^0.19.1"
+
 truffle-provisioner@^0.1.0, truffle-provisioner@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/truffle-provisioner/-/truffle-provisioner-0.1.0.tgz#029e5249c1015300738535e04fded931a53c4f62"
@@ -5768,9 +5814,9 @@ truffle-solidity-utils@~1.0.0:
   dependencies:
     solidity-parser "^0.3.0"
 
-truffle@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-3.2.1.tgz#88e90ed0740a6b4a6e4cfdbb6cf557959084fbdd"
+truffle@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-3.2.2.tgz#540a09922b01fc41d59162a7a88e398a8be3de31"
   dependencies:
     async "^1.4.2"
     chai "^3.3.0"
@@ -5791,7 +5837,7 @@ truffle@3.2.1:
     spawn-args "^0.1.0"
     temp "^0.8.3"
     truffle-artifactor "~2.1.4"
-    truffle-compile "~1.1.2"
+    truffle-compile "~2.0.0"
     truffle-config "~0.0.7"
     truffle-contract "~2.0.0"
     truffle-contract-sources "~0.0.1"
@@ -5855,6 +5901,10 @@ typedarray-to-buffer@^3.1.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typify-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/typify-parser/-/typify-parser-1.1.0.tgz#ac73bfa5f25343468e2d0f3346c6117bc03d3c99"
 
 uglify-js@^2.8.27:
   version "2.8.29"
@@ -6050,6 +6100,16 @@ web3@^0.18.0, web3@^0.18.2, web3@^0.18.4:
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
   dependencies:
     bignumber.js "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+    crypto-js "^3.1.4"
+    utf8 "^2.1.1"
+    xhr2 "*"
+    xmlhttprequest "*"
+
+web3@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-0.19.1.tgz#e763d5b1107c4bc24abd4f8cbee1ba3659e6eb31"
+  dependencies:
+    bignumber.js "^4.0.2"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"
@@ -6305,8 +6365,8 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-zeppelin-solidity@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.0.6.tgz#18df444fee2164b558da16427da068e46b71bbe8"
+zeppelin-solidity@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.1.0.tgz#89fc596610dc273698e5580457eeb84add2213d7"
   dependencies:
     truffle-hdwallet-provider "0.0.3"


### PR DESCRIPTION
Adds a property based test which generates a crowdsale and a sequence of commands to run on that crowdsale. It runs the commands, checking some invariants/properties that must be true on every command that is run.

The interesting thing is that any sequence of commands can be generated, in ways that unit tests would not cover (because it's too expensive to write all the possible combinations so we only write a few specific combinations that we as developers think should cover most of the important/edge cases).

Example of a property:

> `submitBid` must throw an exception if the status of the crowdsale is not equal to 2 (which means that the crowdsale is started)

### Commands to implement:

- [x] waitBlock
- [x] checkPrice
- [x] submitBid
- [x] setStatus
- [ ] addPresalePayment
- [ ] distributeTokens
- [x] checkCrowdsale

### Verify resulting state:

- [x] Verify status (stopped, started, finished)
- [ ] Verify token ether balance
- [ ] Verify token tokens balance
- [ ] Verify contract ether balance
- [ ] Verify contract tokens balance
- [ ] Verify each account tokens balance
- [ ] Verify each account ether balance (add claimEth command?)
- [ ] Verify founders future payments
- [ ] Verify presale payments

Fixes #25