### PR TITLE
Add private presale tokens on LifCrowdsale with test command

### DIFF
--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -137,15 +137,15 @@ contract LifCrowdsale is Ownable, Pausable {
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
   }
 
-  function addPrivatePresaleTokens(address beneficiary, uint256 totalWei) onlyOwner {
+  function addPrivatePresaleTokens(address beneficiary, uint256 weiSent) onlyOwner {
     require(block.number < startBlock);
     require(beneficiary != address(0));
-    require(totalWei > 0);
+    require(weiSent > 0);
 
-    uint256 tokens = totalWei.mul(privatePresaleRate);
+    uint256 tokens = weiSent.mul(privatePresaleRate);
 
     uint256 presaleWei = totalPresaleWei;
-    require(presaleWei.add(totalWei) <= maxPresaleWei);
+    require(presaleWei.add(weiSent) <= maxPresaleWei);
 
     totalPresaleWei.add(tokens);
 

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -144,10 +144,9 @@ contract LifCrowdsale is Ownable, Pausable {
 
     uint256 tokens = weiSent.mul(privatePresaleRate);
 
-    uint256 presaleWei = totalPresaleWei;
-    require(presaleWei.add(weiSent) <= maxPresaleWei);
+    require(totalPresaleWei.add(weiSent) <= maxPresaleWei);
 
-    totalPresaleWei.add(tokens);
+    totalPresaleWei.add(weiSent);
 
     token.mint(beneficiary, tokens);
   }

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -31,10 +31,13 @@ contract LifCrowdsale is Ownable, Pausable {
   // amount of raised money in wei
   uint256 public weiRaised;
 
+  // total amount of tokens sold on the ICO
   uint256 public tokensSold;
 
+  // total amount of wei received as presale payments (both private and public)
   uint256 public totalPresaleWei;
 
+  // maximun amount of ether that can be raised using presale payments in wei unit
   uint256 public maxPresaleWei;
 
   //  minimun amount of wei to be raised in order to succed

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -20,6 +20,9 @@ contract LifCrowdsale is Ownable, Pausable {
   address public foundationWallet;
   address public marketMaker;
 
+  // how much wei a token unit costs to a buyer, during the private presale stage
+  uint256 public privatePresaleRate;
+
   // how much wei a token unit costs to a buyer, during the first half of the crowdsale
   uint256 public rate1;
   // how much wei a token unit costs to a buyer, during the second half of the crowdsale
@@ -29,6 +32,10 @@ contract LifCrowdsale is Ownable, Pausable {
   uint256 public weiRaised;
 
   uint256 public tokensSold;
+
+  uint256 public totalPresaleWei;
+
+  uint256 public maxPresaleWei;
 
   //  minimun amount of wei to be raised in order to succed
   uint256 public minCap;
@@ -59,9 +66,11 @@ contract LifCrowdsale is Ownable, Pausable {
     uint256 _endBlock2,
     uint256 _rate1,
     uint256 _rate2,
+    uint256 _privatePresaleRate,
     address _foundationWallet,
     address _marketMaker,
-    uint256 _minCap
+    uint256 _minCap,
+    uint256 _maxPresaleWei
   ) {
     require(_startBlock >= block.number);
     require(_endBlock1 > _startBlock);
@@ -80,9 +89,11 @@ contract LifCrowdsale is Ownable, Pausable {
     endBlock2 = _endBlock2;
     rate1 = _rate1;
     rate2 = _rate2;
+    privatePresaleRate = _privatePresaleRate;
     foundationWallet = _foundationWallet;
     marketMaker = _marketMaker;
     minCap = _minCap;
+    maxPresaleWei = _maxPresaleWei;
   }
 
   // returns the current rate or 0 if current block is not within the crowdsale period
@@ -126,10 +137,17 @@ contract LifCrowdsale is Ownable, Pausable {
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
   }
 
-  function addPresaleTokens(address beneficiary, uint256 tokens) onlyOwner {
+  function addPrivatePresaleTokens(address beneficiary, uint256 totalWei) onlyOwner {
     require(block.number < startBlock);
     require(beneficiary != address(0));
-    require(tokens > 0);
+    require(totalWei > 0);
+
+    uint256 tokens = totalWei.mul(privatePresaleRate);
+
+    uint256 presaleWei = totalPresaleWei;
+    require(presaleWei.add(totalWei) <= maxPresaleWei);
+
+    totalPresaleWei.add(tokens);
 
     token.mint(beneficiary, tokens);
   }

--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -18,9 +18,10 @@ contract('LifToken Crowdsale', function(accounts) {
 
     let crowdsale = await LifCrowdsale.new(
       startBlock, endBlock1, endBlock2,
-      100, 110,
+      100, 110, 130,
       accounts[0], accounts[1],
-      100000000
+      100000000,
+      20000000
     );
 
     assert.equal(startBlock, parseInt(await crowdsale.startBlock.call()));

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -27,9 +27,11 @@ contract('LifCrowdsale Property-based test', function(accounts) {
   let crowdsaleGen = jsc.record({
     rate1: jsc.nat,
     rate2: jsc.nat,
+    privatePresaleRate: jsc.nat,
     foundationWallet: accountGen,
     marketMaker: accountGen,
-    minCapEth: jsc.number(0, 200)
+    minCapEth: jsc.number(0, 200),
+    maxPresaleEth: jsc.number(0, 200)
   });
 
   let waitBlockCommandGen = jsc.record({
@@ -64,12 +66,11 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     type: jsc.constant("checkCrowdsale"),
     fromAccount: accountGen
   });
-  let addPresalePaymentCommandGen = jsc.record({
-    type: jsc.constant("addPresalePayment"),
-    account: accountGen,
+  let addPrivatePresalePaymentCommandGen = jsc.record({
+    type: jsc.constant("addPrivatePresalePayment"),
+    beneficiaryAccount: accountGen,
     fromAccount: accountGen,
-    amountEth: jsc.number(),
-    addFunding: jsc.bool // issue & transfer the necessary tokens for this payment?
+    tokens: jsc.nat(0,200)
   });
 
   let runWaitBlockCommand = async (command, state) => {
@@ -208,46 +209,35 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     return state;
   };
 
-  let runAddPresalePaymentCommand = async (command, state) => {
-    let fundingShouldThrow = (state.crowdsaleData.startPriceEth == 0) ||
-      (command.amountEth <= 0) ||
-      (state.crowdsaleData.presaleBonusRate <= 0);
+  let runAddPrivatePresalePaymentCommand = async (command, state) => {
 
-    if (command.addFunding) {
-      let { minCap, presaleBonusRate, maxTokens } = state.crowdsaleData;
-      let minCapEth = web3.fromWei(minCap, 'ether');
-      let presaleMaxTokens = help.getPresalePaymentMaxTokens(minCapEth, maxTokens, presaleBonusRate, command.amountEth);
-      let presaleMaxWei = Math.ceil(help.lif2LifWei(presaleMaxTokens));
+    let crowdsale = state.crowdsaleData,
+      { startBlock, endBlock2, maxPresaleWei, privatePresaleRate } = crowdsale,
+      nextBlock = web3.eth.blockNumber + 1,
+      tokens = command.tokens,
+      totalWei = web3.toWei( tokens * ( 1 / privatePresaleRate)),
+      account = accounts[command.fromAccount],
+      beneficiary = accounts[command.beneficiaryAccount];
 
-      try {
-        await token.issueTokens(Math.ceil(presaleMaxTokens));
-        await token.transferFrom(token.address, state.crowdsaleContract.address, presaleMaxWei, {from: accounts[0]});
-        assert.equal(false, fundingShouldThrow);
-      } catch(e) {
-        if (!fundingShouldThrow)
-          throw(e);
-      }
-    }
-
-    // tweak shouldThrow based on the current blockNumber, right before the addPresalePayment tx
-    let shouldThrow = fundingShouldThrow ||
-      (command.fromAccount != 0) ||
-      !command.addFunding ||
-      (web3.eth.blockNumber >= state.crowdsaleData.startBlock);
+    let shouldThrow = (nextBlock >= startBlock) ||
+      (state.crowdsalePaused) ||
+      (account != accounts[0]) ||
+      (state.crowdsaleFinalized) ||
+      (tokens == 0) ||
+      ((state.totalPresaleWei + totalWei) > maxPresaleWei);
 
     try {
-      await state.crowdsaleContract.addPresalePayment(
-        accounts[command.account],
-        web3.toWei(command.amountEth, 'ether'),
-        {from: accounts[command.fromAccount]}
-      );
-      assert.equal(false, shouldThrow);
-      state.presalePayments = _.concat(state.presalePayments, {amountEth: command.amountEth, account: command.account});
-    } catch (e) {
-      if (!shouldThrow)
-        throw(new ExceptionRunningCommand(e, state, command));   
-    }
+      help.debug("Adding presale private tokens for account:", command.beneficiaryAccount, "tokens:", tokens, "fromAccount:", command.fromAccount, "blockNumber:", nextBlock);
 
+      await state.crowdsaleContract.addPrivatePresaleTokens(beneficiary, tokens, {from: account});
+
+      assert.equal(false, shouldThrow, "buyTokens should have thrown but it didn't");
+
+      state.totalPresaleWei += totalWei;
+    } catch(e) {
+      if (!shouldThrow)
+        throw(new ExceptionRunningCommand(e, state, command));
+    }
     return state;
   };
 
@@ -257,9 +247,10 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     buyTokens: {gen: buyTokensCommandGen, run: runBuyTokensCommand},
     pauseCrowdsale: {gen: pauseCrowdsaleCommandGen, run: runPauseCrowdsaleCommand},
     pauseToken: {gen: pauseTokenCommandGen, run: runPauseTokenCommand},
-    finalizeCrowdsale: {gen: finalizeCrowdsaleCommandGen, run: runFinalizeCrowdsaleCommand}
+    finalizeCrowdsale: {gen: finalizeCrowdsaleCommandGen, run: runFinalizeCrowdsaleCommand},
+    addPrivatePresalePayment: {gen: addPrivatePresalePaymentCommandGen, run: runAddPrivatePresalePaymentCommand}
     // checkCrowdsale: {gen: checkCrowdsaleCommandGen, run: runCheckCrowdsaleCommand},
-    // addPresalePayment: {gen: addPresalePaymentCommandGen, run: runAddPresalePaymentCommand}
+
   };
 
   let commandsGen = jsc.nonshrink(jsc.oneof(_.map(commands, (c) => c.gen)));
@@ -278,6 +269,9 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     */
     help.debug("checking purchases total wei, purchases:", JSON.stringify(state.purchases));
     assert.equal(_.sumBy(state.purchases, (b) => b.wei), parseInt(await crowdsale.weiRaised.call()));
+
+    // Check presale tokens sold
+    assert.equal(state.totalPresaleWei, parseInt(await crowdsale.totalPresaleWei.call()));
   }
 
   let runGeneratedCrowdsaleAndCommands = async function(input) {
@@ -302,9 +296,11 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         startBlock: startBlock, endBlock1: endBlock1, endBlock2: endBlock2,
         rate1: input.crowdsale.rate1,
         rate2: input.crowdsale.rate2,
+        privatePresaleRate: input.crowdsale.privatePresaleRate,
         foundationWallet: accounts[input.crowdsale.foundationWallet],
         marketMaker: accounts[input.crowdsale.marketMaker],
-        minCap: web3.toWei(input.crowdsale.minCapEth, 'ether')
+        minCap: web3.toWei(input.crowdsale.minCapEth, 'ether'),
+        maxPresaleWei: web3.toWei(input.crowdsale.maxPresaleEth, 'ether')
       };
 
       let crowdsale = await LifCrowdsale.new(
@@ -313,9 +309,11 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         crowdsaleData.endBlock2,
         crowdsaleData.rate1,
         crowdsaleData.rate2,
+        crowdsaleData.privatePresaleRate,
         crowdsaleData.foundationWallet,
         crowdsaleData.marketMaker,
         crowdsaleData.minCap,
+        crowdsaleData.maxPresaleWei,
         {from: accounts[0]}
       );
 
@@ -341,6 +339,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         purchases: [],
         presalePurchases: [],
         weiRaised: 0,
+        totalPresaleWei: 0,
         crowdsalePaused: false,
         tokenPaused: false,
         crowdsaleFinalized: false

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -215,7 +215,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       { startBlock, endBlock2, maxPresaleWei, privatePresaleRate } = crowdsale,
       nextBlock = web3.eth.blockNumber + 1,
       tokens = command.tokens,
-      totalWei = web3.toWei( tokens * ( 1 / privatePresaleRate)),
+      weiToSend = web3.toWei( tokens * ( 1 / privatePresaleRate)),
       account = accounts[command.fromAccount],
       beneficiary = accounts[command.beneficiaryAccount];
 
@@ -224,7 +224,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       (account != accounts[0]) ||
       (state.crowdsaleFinalized) ||
       (tokens == 0) ||
-      ((state.totalPresaleWei + totalWei) > maxPresaleWei);
+      ((state.totalPresaleWei + weiToSend) > maxPresaleWei);
 
     try {
       help.debug("Adding presale private tokens for account:", command.beneficiaryAccount, "tokens:", tokens, "fromAccount:", command.fromAccount, "blockNumber:", nextBlock);
@@ -233,7 +233,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
       assert.equal(false, shouldThrow, "buyTokens should have thrown but it didn't");
 
-      state.totalPresaleWei += totalWei;
+      state.totalPresaleWei += weiToSend;
     } catch(e) {
       if (!shouldThrow)
         throw(new ExceptionRunningCommand(e, state, command));


### PR DESCRIPTION
Add function for the owner of the crowdsale to add tokens to addresses, this tokens are taken in count as private presale payments. The owner has a maximun amount of tokens that he can add, thats why I also added a maxPrivatePresaleTokens variable on the contract.