### PR TITLE
Tests: Add isInvalidOpcodeEx and improve exception handling

### DIFF
--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -76,7 +76,7 @@ contract('LifToken', function(accounts) {
     try {
       await token.transfer(accounts[2], help.lif2LifWei(21));
     } catch (error) {
-      if (error.message.search('invalid opcode') == -1) throw error;
+      if (!help.isInvalidOpcodeEx(error)) throw error;
     }
     await help.checkToken(token, accounts, 100, [40,30,20,10,0]);
   });
@@ -92,7 +92,7 @@ contract('LifToken', function(accounts) {
     try {
       await token.transferFrom(accounts[1], accounts[3], help.lif2LifWei(11), {from: accounts[3]});
     } catch (error) {
-      if (error.message.search('invalid opcode') == -1) throw error;
+      if (!help.isInvalidOpcodeEx(error)) throw error;
     }
     await help.checkToken(token, accounts, 100, [40,30,20,10,0]);
   });
@@ -157,7 +157,7 @@ contract('LifToken', function(accounts) {
     try {
       await token.transferData(token.contract.address, help.lif2LifWei(1000), web3.toHex(0), {from: accounts[1]});
     } catch (error) {
-      if (error.message.search('invalid opcode') == -1) throw error;
+      if (!help.isInvalidOpcodeEx(error)) throw error;
     }
 
     await help.checkToken(token, accounts, 100, [40,30,20,10,0]);
@@ -170,7 +170,7 @@ contract('LifToken', function(accounts) {
     try {
       await token.transferDataFrom(accounts[3], token.contract.address, help.lif2LifWei(1), web3.toHex(0), {from: accounts[1]});
     } catch (error) {
-      if (error.message.search('invalid opcode') == -1) throw error;
+      if (!help.isInvalidOpcodeEx(error)) throw error;
     }
 
     await help.checkToken(token, accounts, 100, [40,30,20,10,0]);
@@ -194,7 +194,7 @@ contract('LifToken', function(accounts) {
     try {
       await token.burn(burned, {from: accounts[5]});
     } catch (error) {
-      if (error.message.search('invalid opcode') == -1) throw error;
+      if (!help.isInvalidOpcodeEx(error)) throw error;
     }
     await token.unpause({from: accounts[0]});
 

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -75,6 +75,7 @@ contract('LifToken', function(accounts) {
   it("should throw an error when trying to transfer more than balance", async function() {
     try {
       await token.transfer(accounts[2], help.lif2LifWei(21));
+      assert(false, "transfer should have thrown");
     } catch (error) {
       if (!help.isInvalidOpcodeEx(error)) throw error;
     }
@@ -91,6 +92,7 @@ contract('LifToken', function(accounts) {
     await token.approve(accounts[3], help.lif2LifWei(10), {from: accounts[1]});
     try {
       await token.transferFrom(accounts[1], accounts[3], help.lif2LifWei(11), {from: accounts[3]});
+      assert(false, "transferFrom should have thrown");
     } catch (error) {
       if (!help.isInvalidOpcodeEx(error)) throw error;
     }
@@ -156,6 +158,7 @@ contract('LifToken', function(accounts) {
 
     try {
       await token.transferData(token.contract.address, help.lif2LifWei(1000), web3.toHex(0), {from: accounts[1]});
+      assert(false, "transferData should have thrown");
     } catch (error) {
       if (!help.isInvalidOpcodeEx(error)) throw error;
     }
@@ -169,6 +172,7 @@ contract('LifToken', function(accounts) {
 
     try {
       await token.transferDataFrom(accounts[3], token.contract.address, help.lif2LifWei(1), web3.toHex(0), {from: accounts[1]});
+      assert(false, "transferDataFrom should have thrown");
     } catch (error) {
       if (!help.isInvalidOpcodeEx(error)) throw error;
     }
@@ -193,6 +197,7 @@ contract('LifToken', function(accounts) {
 
     try {
       await token.burn(burned, {from: accounts[5]});
+      assert(false, "burn should have thrown");
     } catch (error) {
       if (!help.isInvalidOpcodeEx(error)) throw error;
     }

--- a/test/commands.js
+++ b/test/commands.js
@@ -7,6 +7,11 @@ var gen = require("./generators");
 
 const accounts = web3.eth.accounts;
 
+let assertExpectedException = (e, shouldThrow, state, command) => {
+  if (!shouldThrow || !help.isInvalidOpcodeEx(e))
+    throw(new ExceptionRunningCommand(e, state, command));
+}
+
 let runWaitBlockCommand = async (command, state) => {
   await help.waitBlocks(command.blocks, accounts);
   return state;
@@ -63,8 +68,7 @@ let runBuyTokensCommand = async (command, state) => {
     state.weiRaised += weiCost;
 
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 }
@@ -99,8 +103,7 @@ let runBuyPresaleTokensCommand = async (command, state) => {
     state.totalPresaleWei += weiCost;
 
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 }
@@ -145,8 +148,7 @@ let runSendTransactionCommand = async (command, state) => {
       state.totalPresaleWei += weiCost;
     }
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 }
@@ -164,8 +166,7 @@ let runBurnTokensCommand = async (command, state) => {
     state.balances[account] = balance - command.tokens;
 
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -186,8 +187,7 @@ let runSetWeiPerUSDinPresaleCommand = async (command, state) => {
     assert.equal(false, shouldThrow);
     state.weiPerUSDinPresale = command.wei;
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -208,8 +208,7 @@ let runSetWeiPerUSDinTGECommand = async (command, state) => {
     assert.equal(false, shouldThrow);
     state.weiPerUSDinTGE = command.wei;
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -228,8 +227,7 @@ let runPauseCrowdsaleCommand = async (command, state) => {
     assert.equal(false, shouldThrow);
     state.crowdsalePaused = command.pause;
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -249,8 +247,7 @@ let runPauseTokenCommand = async (command, state) => {
     assert.equal(false, shouldThrow);
     state.tokenPaused = command.pause;
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -286,8 +283,7 @@ let runFinalizeCrowdsaleCommand = async (command, state) => {
     state.crowdsaleFinalized = true;
     state.crowdsaleFunded = crowdsaleFunded;
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -316,8 +312,7 @@ let runAddPrivatePresalePaymentCommand = async (command, state) => {
 
     state.totalPresaleWei += weiToSend;
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 };
@@ -342,8 +337,7 @@ let runClaimEthCommand = async (command, state) => {
 
     state.claimedEth[command.account] = _.sumBy(purchases, (p) => p.amount);
   } catch(e) {
-    if (!shouldThrow)
-      throw(new ExceptionRunningCommand(e, state, command));
+    assertExpectedException(e, shouldThrow, state, command);
   }
   return state;
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -50,6 +50,10 @@ module.exports = {
     return web3.toWei(parseFloat(ether), 'wei');
   },
 
+  isInvalidOpcodeEx: function(e) {
+    return e.message.search('invalid opcode') >= 0;
+  },
+
   waitBlocks: function(toWait, accounts){
     return this.waitToBlock(parseInt(web3.eth.blockNumber) + toWait, accounts);
   },


### PR DESCRIPTION
We were considering any exception in the shouldThrow usual block in the
gen tests commands. The idea is that shouldThrow means whether the
transaction should throw on the blockchain or not, and it's usually
with the invalid opcode error, not with any error. This change makes
it so we only accept invalid opcode exception as the expected thrown
exception. Other kinds of exceptions should make the test to fail