### PR TITLE
Add timestamps on LifCrowdsale

### DIFF
--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -1,26 +1,30 @@
 var LifCrowdsale = artifacts.require("./LifCrowdsale.sol");
 
+var latestTime = require('./helpers/latestTime');
+var {duration} = require('./helpers/increaseTime');
+
+
 contract('LifToken Crowdsale', function(accounts) {
 
   it("can create a Crowndsale", async function() {
-    const publicPresaleStartBlock = web3.eth.blockNumber + 10,
-      publicPresaleEndBlock = publicPresaleStartBlock + 10,
-      startBlock = publicPresaleEndBlock + 10,
-      endBlock1 = startBlock + 15,
-      endBlock2 = startBlock + 20;
+    const publicPresaleStartTimestamp = latestTime() + duration.days(1),
+      publicPresaleEndTimestamp = publicPresaleStartTimestamp + duration.days(1),
+      startTimestamp = publicPresaleEndTimestamp + duration.days(1),
+      end1Timestamp = startTimestamp + duration.days(1),
+      end2Timestamp = startTimestamp + duration.days(2);
 
     let crowdsale = await LifCrowdsale.new(
-      publicPresaleStartBlock, publicPresaleEndBlock,
-      startBlock, endBlock1, endBlock2,
+      publicPresaleStartTimestamp, publicPresaleEndTimestamp,
+      startTimestamp, end1Timestamp, end2Timestamp,
       130, 100, 110, 150, 5,
       accounts[0]
     );
 
-    assert.equal(publicPresaleStartBlock, parseInt(await crowdsale.publicPresaleStartBlock.call()));
-    assert.equal(publicPresaleEndBlock, parseInt(await crowdsale.publicPresaleEndBlock.call()));
-    assert.equal(startBlock, parseInt(await crowdsale.startBlock.call()));
-    assert.equal(endBlock1, parseInt(await crowdsale.endBlock1.call()));
-    assert.equal(endBlock2, parseInt(await crowdsale.endBlock2.call()));
+    assert.equal(publicPresaleStartTimestamp, parseInt(await crowdsale.publicPresaleStartTimestamp.call()));
+    assert.equal(publicPresaleEndTimestamp, parseInt(await crowdsale.publicPresaleEndTimestamp.call()));
+    assert.equal(startTimestamp, parseInt(await crowdsale.startTimestamp.call()));
+    assert.equal(end1Timestamp, parseInt(await crowdsale.end1Timestamp.call()));
+    assert.equal(end2Timestamp, parseInt(await crowdsale.end2Timestamp.call()));
     assert.equal(100, parseInt(await crowdsale.rate1.call()));
     assert.equal(110, parseInt(await crowdsale.rate2.call()));
     assert.equal(accounts[0], parseInt(await crowdsale.foundationWallet.call()));

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 var jsc = require("jsverify");
 
 var help = require("./helpers");
+var latestTime = require('./helpers/latestTime');
+var {increaseTimeTestRPC, increaseTimeTestRPCTo, duration} = require('./helpers/increaseTime');
 
 var LifToken = artifacts.require("./LifToken.sol");
 var LifCrowdsale = artifacts.require("./LifCrowdsale.sol");
@@ -50,31 +52,32 @@ contract('LifCrowdsale Property-based test', function(accounts) {
   }
 
   let runGeneratedCrowdsaleAndCommands = async function(input) {
-    let publicPresaleStartBlock = web3.eth.blockNumber + 10;
-    let publicPresaleEndBlock = publicPresaleStartBlock + 10;
-    let startBlock = publicPresaleEndBlock + 10;
-    let endBlock1 = startBlock + 10;
-    let endBlock2 = endBlock1 + 10;
+    await increaseTimeTestRPC(60);
+    let publicPresaleStartTime = latestTime() + duration.days(1);
+    let publicPresaleEndTime = publicPresaleStartTime + duration.days(1);
+    let startTime = publicPresaleEndTime + duration.days(1);
+    let endTime1 = startTime + duration.days(1);
+    let endTime2 = endTime1 + duration.days(1);
 
-    help.debug("crowdsaleTestInput data:\n", input, publicPresaleStartBlock, publicPresaleEndBlock, startBlock, endBlock1, endBlock2);
+    help.debug("crowdsaleTestInput data:\n", input, publicPresaleStartTime, publicPresaleEndTime, startTime, endTime1, endTime2);
 
     let {publicPresaleRate, rate1, rate2, owner, setWeiLockBlocks} = input.crowdsale,
       ownerAddress = accounts[input.crowdsale.owner];
     let shouldThrow = (publicPresaleRate == 0) ||
       (rate1 == 0) ||
       (rate2 == 0) ||
-      (publicPresaleStartBlock >= publicPresaleEndBlock) ||
-      (publicPresaleEndBlock >= startBlock) ||
-      (startBlock >= endBlock1) ||
-      (endBlock1 >= endBlock2) ||
+      (publicPresaleStartTime >= publicPresaleEndTime) ||
+      (publicPresaleEndTime >= startTime) ||
+      (startTime >= endTime1) ||
+      (endTime1 >= endTime2) ||
       (setWeiLockBlocks == 0)
 
     var eventsWatcher;
 
     try {
       let crowdsaleData = {
-        publicPresaleStartBlock: publicPresaleStartBlock, publicPresaleEndBlock: publicPresaleEndBlock,
-        startBlock: startBlock, endBlock1: endBlock1, endBlock2: endBlock2,
+        publicPresaleStartTime: publicPresaleStartTime, publicPresaleEndTime: publicPresaleEndTime,
+        startTime: startTime, endTime1: endTime1, endTime2: endTime2,
         publicPresaleRate: input.crowdsale.publicPresaleRate,
         rate1: input.crowdsale.rate1,
         rate2: input.crowdsale.rate2,
@@ -88,11 +91,11 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       };
 
       let crowdsale = await LifCrowdsale.new(
-        crowdsaleData.publicPresaleStartBlock,
-        crowdsaleData.publicPresaleEndBlock,
-        crowdsaleData.startBlock,
-        crowdsaleData.endBlock1,
-        crowdsaleData.endBlock2,
+        crowdsaleData.publicPresaleStartTime,
+        crowdsaleData.publicPresaleEndTime,
+        crowdsaleData.startTime,
+        crowdsaleData.endTime1,
+        crowdsaleData.endTime2,
         crowdsaleData.publicPresaleRate,
         crowdsaleData.rate1,
         crowdsaleData.rate2,
@@ -143,7 +146,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
           state = await command.run(commandParams, state);
         }
         catch(error) {
-          help.debug("An error occurred, block number: " + web3.eth.blockNumber + "\nError: " + error);
+          help.debug("An error occurred, block timestamp: " + latestTime() + "\nError: " + error);
           if (error instanceof commands.ExceptionRunningCommand) {
             throw(new Error("command " + JSON.stringify(commandParams) + " has thrown."
               + "\nError: " + error.error));
@@ -174,44 +177,45 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
     await runGeneratedCrowdsaleAndCommands({
       commands: [
-        {"type":"waitBlock","blocks":10},
-        {"type":"sendTransaction","account":3,"beneficiary":0,"eth":9}
+        { type: "waitTime","seconds":duration.days(1)},
+        { type:"sendTransaction","account":3,"beneficiary":0,"eth":9}
       ],
       crowdsale: {
         publicPresaleRate: 33, rate1: 18, rate2: 33, privatePresaleRate: 48,
-        foundationWallet: 1, setWeiLockBlocks: 1, owner: 7
+        foundationWallet: 1, setWeiLockBlocks: 600, owner: 7
       }
     });
 
     await runGeneratedCrowdsaleAndCommands({
       commands: [
-        {"type":"waitBlock","blocks":27},
-        {"type":"pauseCrowdsale","pause":true,"fromAccount":8},
-        {"type":"sendTransaction","account":0,"beneficiary":9,"eth":39}
+        { type: "waitTime","seconds":duration.days(2.6)},
+        { type:"pauseCrowdsale","pause":true,"fromAccount":8},
+        { type:"sendTransaction","account":0,"beneficiary":9,"eth":39}
       ],
       crowdsale: {
         publicPresaleRate: 1, rate1: 39, rate2: 13, privatePresaleRate: 35,
-        foundationWallet: 8, setWeiLockBlocks: 1, owner: 9
+        foundationWallet: 8, setWeiLockBlocks: 600, owner: 9
       }
     });
 
   });
 
-  it("calculates correct rate on the boundaries between endBlock1 and endBlock2", async function() {
+  it("calculates correct rate on the boundaries between endTime1 and endTime2", async function() {
     let crowdsaleAndCommands = {
       commands: [
-        { type: 'checkRate' },
-        { type: 'setWeiPerUSDinPresale', wei: 3000000000000000, fromAccount: 3 },
-        { type: 'checkRate' },
-        { type: 'waitBlock', blocks: 29 },
-        { type: 'buyTokens', beneficiary: 3, account: 2, eth: 12 }
+        { type: "checkRate" },
+        { type: "waitTime","seconds":duration.minutes(1430)},
+        { type: "setWeiPerUSDinPresale", wei: 3000000000000000, fromAccount: 3 },
+        { type: "checkRate" },
+        { type: "waitTime","seconds":duration.days(2.9)},
+        { type: "buyTokens", beneficiary: 3, account: 2, eth: 12 }
       ],
       crowdsale: {
         publicPresaleRate: 20,
         rate1: 16,
         rate2: 14,
         privatePresaleRate: 14,
-        setWeiLockBlocks: 5,
+        setWeiLockBlocks: 3600,
         foundationWallet: 2,
         owner: 3
       }
@@ -223,25 +227,24 @@ contract('LifCrowdsale Property-based test', function(accounts) {
   it("Execute a normal presale and TGE", async function() {
     let crowdsaleAndCommands = {
       commands: [
-        { type: 'checkRate' },
-        { type: 'setWeiPerUSDinPresale', wei: 3000000000000000, fromAccount: 3 },
-        { type: 'waitBlock', blocks: 10 },
-        { type: 'buyPresaleTokens', beneficiary: 3, account: 4, eth: 3000 },
-        { type: 'waitBlock', blocks: 8 },
-        { type: 'setWeiPerUSDinTGE', wei: 1500000000000000, fromAccount: 3 },
-        { type: 'waitBlock', blocks: 12 },
-        { type: 'buyTokens', beneficiary: 3, account: 4, eth: 40000 },
-        { type: 'waitBlock', blocks: 10 },
-        { type: 'buyTokens', beneficiary: 3, account: 4, eth: 23000 },
-        { type: 'waitBlock', blocks: 10 },
-        { type: 'finalizeCrowdsale', fromAccount: 5 }
+        { type: "checkRate" },
+        { type: "setWeiPerUSDinPresale", wei: 3000000000000000, fromAccount: 3 },
+        { type: "waitTime","seconds":duration.days(2)},
+        { type: "buyPresaleTokens", beneficiary: 3, account: 4, eth: 3000 },
+        { type: "setWeiPerUSDinTGE", wei: 1500000000000000, fromAccount: 3 },
+        { type: "waitTime","seconds":duration.days(1)},
+        { type: "buyTokens", beneficiary: 3, account: 4, eth: 40000 },
+        { type: "waitTime","seconds":duration.days(1)},
+        { type: "buyTokens", beneficiary: 3, account: 4, eth: 23000 },
+        { type: "waitTime","seconds":duration.days(1)},
+        { type: "finalizeCrowdsale", fromAccount: 5 }
       ],
       crowdsale: {
         publicPresaleRate: 11,
         rate1: 10,
         rate2: 9,
         privatePresaleRate: 13,
-        setWeiLockBlocks: 5,
+        setWeiLockBlocks: 3600,
         foundationWallet: 2,
         owner: 3
       }
@@ -253,18 +256,18 @@ contract('LifCrowdsale Property-based test', function(accounts) {
   it("should handle the exception correctly when trying to pause the token during and after the crowdsale", async function() {
     let crowdsaleAndCommands = {
     commands: [
-        { type: 'checkRate' },
-        { type: 'setWeiPerUSDinPresale', wei: 3000000000000000, fromAccount: 3 },
-        { type: 'waitBlock', blocks: 10 },
-        { type: 'buyPresaleTokens', beneficiary: 3, account: 4, eth: 3000 },
-        { type: 'waitBlock', blocks: 8 },
-        { type: 'pauseToken', 'pause':true, 'fromAccount':1 },
-        { type: 'setWeiPerUSDinTGE', wei: 1500000000000000, fromAccount: 3 },
-        { type: 'waitBlock', blocks: 12 },
-        { type: 'buyTokens', beneficiary: 3, account: 4, eth: 60000 },
-        { type: 'waitBlock', blocks: 20 },
-        { type: 'finalizeCrowdsale', fromAccount: 5 },
-        { type: 'pauseToken', 'pause':true, 'fromAccount':1 }
+        { type: "checkRate" },
+        { type: "setWeiPerUSDinPresale", wei: 3000000000000000, fromAccount: 3 },
+        { type: "waitTime","seconds":duration.days(1)},
+        { type: "buyPresaleTokens", beneficiary: 3, account: 4, eth: 3000 },
+        { type: "waitTime","seconds":duration.days(0.8)},
+        { type: "pauseToken", "pause":true, 'fromAccount':1 },
+        { type: "setWeiPerUSDinTGE", wei: 1500000000000000, fromAccount: 3 },
+        { type: "waitTime","seconds":duration.days(1.1)},
+        { type: "buyTokens", beneficiary: 3, account: 4, eth: 60000 },
+        { type: "waitTime","seconds":duration.days(2)},
+        { type: "finalizeCrowdsale", fromAccount: 5 },
+        { type: "pauseToken", "pause":true, 'fromAccount':1 }
       ],
       crowdsale: {
         publicPresaleRate: 11,
@@ -283,9 +286,9 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     // trying multiple commands with different reasons to fail: wrong owner or wei==0
     await runGeneratedCrowdsaleAndCommands({
       commands: [
-        {"type":"setWeiPerUSDinPresale","wei":3,"fromAccount":10},
-        {"type":"setWeiPerUSDinPresale","wei":0,"fromAccount":6},
-        {"type":"setWeiPerUSDinPresale","wei":5,"fromAccount":6}
+        { type:"setWeiPerUSDinPresale","wei":3,"fromAccount":10},
+        { type:"setWeiPerUSDinPresale","wei":0,"fromAccount":6},
+        { type:"setWeiPerUSDinPresale","wei":5,"fromAccount":6}
       ],
       crowdsale: {
         publicPresaleRate: 27, rate1: 10, rate2: 31, privatePresaleRate: 35,
@@ -295,9 +298,9 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
     await runGeneratedCrowdsaleAndCommands({
       commands: [
-        {"type":"setWeiPerUSDinTGE","wei":0,"fromAccount":10},
-        {"type":"setWeiPerUSDinTGE","wei":0,"fromAccount":6},
-        {"type":"setWeiPerUSDinTGE","wei":3,"fromAccount":6}
+        { type:"setWeiPerUSDinTGE","wei":0,"fromAccount":10},
+        { type:"setWeiPerUSDinTGE","wei":0,"fromAccount":6},
+        { type:"setWeiPerUSDinTGE","wei":3,"fromAccount":6}
       ],
       crowdsale: {
         publicPresaleRate: 27, rate1: 10, rate2: 31, privatePresaleRate: 35,
@@ -308,7 +311,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
   it("should handle the thrown exc. when trying to approve on the paused token", async function() {
     await runGeneratedCrowdsaleAndCommands({
-      commands: [{"type":"approve","lif":0,"fromAccount":3,"spenderAccount":5}],
+      commands: [{ type:"approve","lif":0,"fromAccount":3,"spenderAccount":5}],
       crowdsale: {
         publicPresaleRate: 23, rate1: 24, rate2: 15, privatePresaleRate: 15,
         foundationWallet: 2, setWeiLockBlocks: 1, owner: 5

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -53,36 +53,36 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
   let runGeneratedCrowdsaleAndCommands = async function(input) {
     await increaseTimeTestRPC(60);
-    let publicPresaleStartTime = latestTime() + duration.days(1);
-    let publicPresaleEndTime = publicPresaleStartTime + duration.days(1);
-    let startTime = publicPresaleEndTime + duration.days(1);
-    let endTime1 = startTime + duration.days(1);
-    let endTime2 = endTime1 + duration.days(1);
+    let publicPresaleStartTimestamp = latestTime() + duration.days(1);
+    let publicPresaleEndTimestamp = publicPresaleStartTimestamp + duration.days(1);
+    let startTimestamp = publicPresaleEndTimestamp + duration.days(1);
+    let end1Timestamp = startTimestamp + duration.days(1);
+    let end2Timestamp = end1Timestamp + duration.days(1);
 
-    help.debug("crowdsaleTestInput data:\n", input, publicPresaleStartTime, publicPresaleEndTime, startTime, endTime1, endTime2);
+    help.debug("crowdsaleTestInput data:\n", input, publicPresaleStartTimestamp, publicPresaleEndTimestamp, startTimestamp, end1Timestamp, end2Timestamp);
 
-    let {publicPresaleRate, rate1, rate2, owner, setWeiLockBlocks} = input.crowdsale,
+    let {publicPresaleRate, rate1, rate2, owner, setWeiLockSeconds} = input.crowdsale,
       ownerAddress = accounts[input.crowdsale.owner];
     let shouldThrow = (publicPresaleRate == 0) ||
       (rate1 == 0) ||
       (rate2 == 0) ||
-      (publicPresaleStartTime >= publicPresaleEndTime) ||
-      (publicPresaleEndTime >= startTime) ||
-      (startTime >= endTime1) ||
-      (endTime1 >= endTime2) ||
-      (setWeiLockBlocks == 0)
+      (publicPresaleStartTimestamp >= publicPresaleEndTimestamp) ||
+      (publicPresaleEndTimestamp >= startTimestamp) ||
+      (startTimestamp >= end1Timestamp) ||
+      (end1Timestamp >= end2Timestamp) ||
+      (setWeiLockSeconds == 0)
 
     var eventsWatcher;
 
     try {
       let crowdsaleData = {
-        publicPresaleStartTime: publicPresaleStartTime, publicPresaleEndTime: publicPresaleEndTime,
-        startTime: startTime, endTime1: endTime1, endTime2: endTime2,
+        publicPresaleStartTimestamp: publicPresaleStartTimestamp, publicPresaleEndTimestamp: publicPresaleEndTimestamp,
+        startTimestamp: startTimestamp, end1Timestamp: end1Timestamp, end2Timestamp: end2Timestamp,
         publicPresaleRate: input.crowdsale.publicPresaleRate,
         rate1: input.crowdsale.rate1,
         rate2: input.crowdsale.rate2,
         privatePresaleRate: input.crowdsale.privatePresaleRate,
-        setWeiLockBlocks: input.crowdsale.setWeiLockBlocks,
+        setWeiLockSeconds: input.crowdsale.setWeiLockSeconds,
         foundationWallet: accounts[input.crowdsale.foundationWallet],
         maxPresaleCapUSD: 1000000,
         minCapUSD: 5000000,
@@ -91,16 +91,16 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       };
 
       let crowdsale = await LifCrowdsale.new(
-        crowdsaleData.publicPresaleStartTime,
-        crowdsaleData.publicPresaleEndTime,
-        crowdsaleData.startTime,
-        crowdsaleData.endTime1,
-        crowdsaleData.endTime2,
+        crowdsaleData.publicPresaleStartTimestamp,
+        crowdsaleData.publicPresaleEndTimestamp,
+        crowdsaleData.startTimestamp,
+        crowdsaleData.end1Timestamp,
+        crowdsaleData.end2Timestamp,
         crowdsaleData.publicPresaleRate,
         crowdsaleData.rate1,
         crowdsaleData.rate2,
         crowdsaleData.privatePresaleRate,
-        crowdsaleData.setWeiLockBlocks,
+        crowdsaleData.setWeiLockSeconds,
         crowdsaleData.foundationWallet,
         {from: ownerAddress}
       );
@@ -182,7 +182,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       ],
       crowdsale: {
         publicPresaleRate: 33, rate1: 18, rate2: 33, privatePresaleRate: 48,
-        foundationWallet: 1, setWeiLockBlocks: 600, owner: 7
+        foundationWallet: 1, setWeiLockSeconds: 600, owner: 7
       }
     });
 
@@ -194,13 +194,13 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       ],
       crowdsale: {
         publicPresaleRate: 1, rate1: 39, rate2: 13, privatePresaleRate: 35,
-        foundationWallet: 8, setWeiLockBlocks: 600, owner: 9
+        foundationWallet: 8, setWeiLockSeconds: 600, owner: 9
       }
     });
 
   });
 
-  it("calculates correct rate on the boundaries between endTime1 and endTime2", async function() {
+  it("calculates correct rate on the boundaries between end1Timestamp and end2Timestamp", async function() {
     let crowdsaleAndCommands = {
       commands: [
         { type: "checkRate" },
@@ -215,7 +215,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         rate1: 16,
         rate2: 14,
         privatePresaleRate: 14,
-        setWeiLockBlocks: 3600,
+        setWeiLockSeconds: 3600,
         foundationWallet: 2,
         owner: 3
       }
@@ -244,7 +244,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         rate1: 10,
         rate2: 9,
         privatePresaleRate: 13,
-        setWeiLockBlocks: 3600,
+        setWeiLockSeconds: 3600,
         foundationWallet: 2,
         owner: 3
       }
@@ -274,7 +274,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         rate1: 10,
         rate2: 9,
         privatePresaleRate: 13,
-        setWeiLockBlocks: 5,
+        setWeiLockSeconds: 5,
         foundationWallet: 2,
         owner: 3
       }
@@ -292,7 +292,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       ],
       crowdsale: {
         publicPresaleRate: 27, rate1: 10, rate2: 31, privatePresaleRate: 35,
-        foundationWallet: 10, setWeiLockBlocks: 1, owner: 6
+        foundationWallet: 10, setWeiLockSeconds: 1, owner: 6
       }
     });
 
@@ -304,7 +304,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       ],
       crowdsale: {
         publicPresaleRate: 27, rate1: 10, rate2: 31, privatePresaleRate: 35,
-        foundationWallet: 10, setWeiLockBlocks: 1, owner: 6
+        foundationWallet: 10, setWeiLockSeconds: 1, owner: 6
       }
     });
   });
@@ -314,7 +314,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       commands: [{ type:"approve","lif":0,"fromAccount":3,"spenderAccount":5}],
       crowdsale: {
         publicPresaleRate: 23, rate1: 24, rate2: 15, privatePresaleRate: 15,
-        foundationWallet: 2, setWeiLockBlocks: 1, owner: 5
+        foundationWallet: 2, setWeiLockSeconds: 1, owner: 5
       }
     });
   });

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -20,31 +20,9 @@ contract('LifToken', function(accounts) {
   var token;
   var eventsWatcher;
 
-  var simulateCrowdsale = async function(rate, balances, accounts) {
-    if (web3.eth.blockNumber < 10)
-      await help.waitToBlock(10-web3.eth.blockNumber, accounts);
-    var startTime = latestTime() + 2;
-    var endTime = startTime + 20;
-    var crowdsale = await LifCrowdsale.new(
-      startTime, startTime+2,
-      startTime+3, startTime+9, endTime,
-      rate-1, rate, rate+10, rate+20, 1,
-      accounts[0]
-    );
-    await crowdsale.setWeiPerUSDinTGE(1);
-    await increaseTimeTestRPCTo(startTime+3);
-    for(i = 0; i < 5; i++) {
-      if (balances[i] > 0)
-        await crowdsale.sendTransaction({ value: web3.toWei(balances[i]/rate, 'ether'), from: accounts[i + 1]});
-    }
-    await increaseTimeTestRPCTo(endTime+1);
-    await crowdsale.finalize();
-    return LifToken.at(await crowdsale.token.call());
-  };
-
   beforeEach(async function() {
     rate = 100000000000;
-    token = await simulateCrowdsale(rate, [40,30,20,10,0], accounts);
+    token = await help.simulateCrowdsale(rate, [40,30,20,10,0], accounts);
     eventsWatcher = token.allEvents();
     eventsWatcher.watch(function(error, log){
       if (LOG_EVENTS)

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -10,6 +10,9 @@ var LifToken = artifacts.require("./LifToken.sol");
 var LifCrowdsale = artifacts.require("./LifCrowdsale.sol");
 var Message = artifacts.require("./Message.sol");
 
+var latestTime = require('./helpers/latestTime');
+var {increaseTimeTestRPC, increaseTimeTestRPCTo, duration} = require('./helpers/increaseTime');
+
 const LOG_EVENTS = true;
 
 contract('LifToken', function(accounts) {
@@ -20,21 +23,21 @@ contract('LifToken', function(accounts) {
   var simulateCrowdsale = async function(rate, balances, accounts) {
     if (web3.eth.blockNumber < 10)
       await help.waitToBlock(10-web3.eth.blockNumber, accounts);
-    var startBlock = web3.eth.blockNumber+3;
-    var endBlock = startBlock+15;
+    var startTime = latestTime() + 2;
+    var endTime = startTime + 20;
     var crowdsale = await LifCrowdsale.new(
-      startBlock+1, startBlock+2,
-      startBlock+3, startBlock+10, endBlock,
+      startTime, startTime+2,
+      startTime+3, startTime+9, endTime,
       rate-1, rate, rate+10, rate+20, 1,
       accounts[0]
     );
     await crowdsale.setWeiPerUSDinTGE(1);
-    await help.waitToBlock(startBlock+3, accounts);
+    await increaseTimeTestRPCTo(startTime+3);
     for(i = 0; i < 5; i++) {
       if (balances[i] > 0)
         await crowdsale.sendTransaction({ value: web3.toWei(balances[i]/rate, 'ether'), from: accounts[i + 1]});
     }
-    await help.waitToBlock(endBlock+1, accounts);
+    await increaseTimeTestRPCTo(endTime+1);
     await crowdsale.finalize();
     return LifToken.at(await crowdsale.token.call());
   };

--- a/test/MarketMaker.js
+++ b/test/MarketMaker.js
@@ -23,30 +23,8 @@ contract('marketMaker', function(accounts) {
   var token;
   var eventsWatcher;
 
-  var simulateCrowdsale = async function(rate, balances, accounts) {
-    if (web3.eth.blockNumber < 10)
-      await help.waitToBlock(10-web3.eth.blockNumber, accounts);
-    var startTime = latestTime() + 2;
-    var endTime = startTime + 20;
-    var crowdsale = await LifCrowdsale.new(
-      startTime, startTime+2,
-      startTime+3, startTime+9, endTime,
-      rate-1, rate, rate+10, rate+20, 1,
-      accounts[0]
-    );
-    await crowdsale.setWeiPerUSDinTGE(1);
-    await increaseTimeTestRPCTo(startTime+3);
-    for(i = 0; i < 5; i++) {
-      if (balances[i] > 0)
-        await crowdsale.sendTransaction({ value: web3.toWei(balances[i]/rate, 'ether'), from: accounts[i + 1]});
-    }
-    await increaseTimeTestRPCTo(endTime+1);
-    await crowdsale.finalize();
-    return LifToken.at(await crowdsale.token.call());
-  };
-
   it("Create 24 months MM", async function() {
-    token = await simulateCrowdsale(100000000000, [40,30,20,10,0], accounts);
+    token = await help.simulateCrowdsale(100000000000, [40,30,20,10,0], accounts);
     await help.checkToken(token, accounts, 100, [40,30,20,10,0]);
 
     mm = await LifMarketMaker.new(
@@ -87,7 +65,7 @@ contract('marketMaker', function(accounts) {
   });
 
   it("Create 48 months MM", async function() {
-    token = await simulateCrowdsale(100000000000, [40,30,20,10,0], accounts);
+    token = await help.simulateCrowdsale(100000000000, [40,30,20,10,0], accounts);
     mm = await LifMarketMaker.new(token.address, web3.eth.blockNumber+10, 100, 48,
       accounts[1], {from: accounts[0]});
 
@@ -131,7 +109,7 @@ contract('marketMaker', function(accounts) {
   });
 
   it("should return correct periods using getCurrentPeriodIndex", async function() {
-    token = await simulateCrowdsale(100000000000, [40,30,20,10,0], accounts);
+    token = await help.simulateCrowdsale(100000000000, [40,30,20,10,0], accounts);
     const startBlock = web3.eth.blockNumber+10;
     const blocksPerPeriod = 12;
 
@@ -163,7 +141,7 @@ contract('marketMaker', function(accounts) {
   });
 
   it("should return correct periods after pausing/unpausing using getCurrentPeriodIndex", async function() {
-    token = await simulateCrowdsale(100, [40,30,20,10,0], accounts);
+    token = await help.simulateCrowdsale(100, [40,30,20,10,0], accounts);
     const startBlock = web3.eth.blockNumber+10;
     const blocksPerPeriod = 12;
 
@@ -231,7 +209,7 @@ contract('marketMaker', function(accounts) {
     // Create MM with balance of 200 ETH and 100 tokens in circulation,
     const priceFactor = 100000;
 
-    token = await simulateCrowdsale(tokenTotalSupply, [tokenTotalSupply], accounts);
+    token = await help.simulateCrowdsale(tokenTotalSupply, [tokenTotalSupply], accounts);
 
     let customer = accounts[1];
     let startingMMBalance = new BigNumber(web3.toWei(200, 'ether'));

--- a/test/MarketMaker.js
+++ b/test/MarketMaker.js
@@ -10,6 +10,9 @@ var LifMarketMaker = artifacts.require("./LifMarketMaker.sol");
 var LifToken = artifacts.require("./LifToken.sol");
 var LifCrowdsale = artifacts.require("./LifCrowdsale.sol");
 
+var latestTime = require('./helpers/latestTime');
+var {increaseTimeTestRPC, increaseTimeTestRPCTo, duration} = require('./helpers/increaseTime');
+
 const LOG_EVENTS = true;
 
 const gasPrice = new BigNumber(100000000000);
@@ -23,23 +26,23 @@ contract('marketMaker', function(accounts) {
   var simulateCrowdsale = async function(rate, balances, accounts) {
     if (web3.eth.blockNumber < 10)
       await help.waitToBlock(10-web3.eth.blockNumber, accounts);
-    var startBlock = web3.eth.blockNumber+3;
-    var endBlock = startBlock+15;
+    var startTime = latestTime() + 2;
+    var endTime = startTime + 20;
     var crowdsale = await LifCrowdsale.new(
-      startBlock+1, startBlock+2,
-      startBlock+3, startBlock+10, endBlock,
+      startTime, startTime+2,
+      startTime+3, startTime+9, endTime,
       rate-1, rate, rate+10, rate+20, 1,
       accounts[0]
     );
     await crowdsale.setWeiPerUSDinTGE(1);
-    await help.waitToBlock(startBlock+3, accounts);
+    await increaseTimeTestRPCTo(startTime+3);
     for(i = 0; i < 5; i++) {
       if (balances[i] > 0)
         await crowdsale.sendTransaction({ value: web3.toWei(balances[i]/rate, 'ether'), from: accounts[i + 1]});
     }
-    await help.waitToBlock(endBlock+1, accounts);
+    await increaseTimeTestRPCTo(endTime+1);
     await crowdsale.finalize();
-    return LifToken.at(await crowdsale.token());
+    return LifToken.at(await crowdsale.token.call());
   };
 
   it("Create 24 months MM", async function() {

--- a/test/VestedPayment.js
+++ b/test/VestedPayment.js
@@ -23,31 +23,9 @@ contract('VestedPayment', function(accounts) {
   var token;
   var eventsWatcher;
 
-  var simulateCrowdsale = async function(rate, balances, accounts) {
-    if (web3.eth.blockNumber < 10)
-      await help.waitToBlock(10-web3.eth.blockNumber, accounts);
-    var startTime = latestTime() + 2;
-    var endTime = startTime + 20;
-    var crowdsale = await LifCrowdsale.new(
-      startTime, startTime+2,
-      startTime+3, startTime+9, endTime,
-      rate-1, rate, rate+10, rate+20, 1,
-      accounts[0]
-    );
-    await crowdsale.setWeiPerUSDinTGE(1);
-    await increaseTimeTestRPCTo(startTime+3);
-    for(i = 0; i < 5; i++) {
-      if (balances[i] > 0)
-        await crowdsale.sendTransaction({ value: web3.toWei(balances[i]/rate, 'ether'), from: accounts[i + 1]});
-    }
-    await increaseTimeTestRPCTo(endTime+1);
-    await crowdsale.finalize();
-    return LifToken.at(await crowdsale.token.call());
-  };
-
   beforeEach(async function() {
     rate = 100000000000;
-    token = await simulateCrowdsale(rate, [100], accounts);
+    token = await help.simulateCrowdsale(rate, [100], accounts);
     eventsWatcher = token.allEvents();
     eventsWatcher.watch(function(error, log){
       if (LOG_EVENTS)

--- a/test/commands.js
+++ b/test/commands.js
@@ -10,6 +10,8 @@ var _ = require('lodash');
 var jsc = require("jsverify");
 var help = require("./helpers");
 var gen = require("./generators");
+var latestTime = require('./helpers/latestTime');
+var {increaseTimeTestRPC, increaseTimeTestRPCTo, duration} = require('./helpers/increaseTime');
 
 const accounts = web3.eth.accounts;
 
@@ -19,7 +21,12 @@ let assertExpectedException = (e, shouldThrow, state, command) => {
 }
 
 let runWaitBlockCommand = async (command, state) => {
-  await help.waitBlocks(command.blocks, accounts);
+  await help.waitBlocks(command.blocks);
+  return state;
+}
+
+let runWaitTimeCommand = async (command, state) => {
+  await increaseTimeTestRPC(command.seconds);
   return state;
 }
 
@@ -33,13 +40,13 @@ ExceptionRunningCommand.prototype = Object.create(Error.prototype);
 ExceptionRunningCommand.prototype.constructor = ExceptionRunningCommand;
 
 let runCheckRateCommand = async (command, state) => {
-  let expectedRate = help.getCrowdsaleExpectedRate(state.crowdsaleData, web3.eth.blockNumber);
+  let expectedRate = help.getCrowdsaleExpectedRate(state.crowdsaleData, latestTime());
   let rate = parseFloat(await state.crowdsaleContract.getRate());
 
   assert.equal(expectedRate, rate,
-    "expected rate is different! Expected: " + expectedRate + ", actual: " + rate + ". blocks: " + web3.eth.blockNumber +
-    ", public presale start/end: " + state.crowdsaleData.publicPresaleStartBlock + "/" + state.crowdsaleData.publicPresaleEndBlock +
-    ", start/end1/end2: " + state.crowdsaleData.startBlock + "/" + state.crowdsaleData.endBlock1 + "/" + state.crowdsaleData.endBlock2);
+    "expected rate is different! Expected: " + expectedRate + ", actual: " + rate + ". blocks: " + web3.eth.blockTimestamp +
+    ", public presale start/end: " + state.crowdsaleData.publicPresaleStartTime + "/" + state.crowdsaleData.publicPresaleEndTime +
+    ", start/end1/end2: " + state.crowdsaleData.startTime + "/" + state.crowdsaleData.endTime1 + "/" + state.crowdsaleData.endTime2);
 
   return state;
 }
@@ -50,23 +57,23 @@ let getBalance = (state, account) => {
 
 let runBuyTokensCommand = async (command, state) => {
   let crowdsale = state.crowdsaleData,
-    { startBlock, endBlock2, weiPerUSDinTGE} = crowdsale,
+    { startTime, endTime2, weiPerUSDinTGE} = crowdsale,
     weiCost = parseInt(web3.toWei(command.eth, 'ether')),
-    nextBlock = web3.eth.blockNumber + 1,
-    rate = help.getCrowdsaleExpectedRate(crowdsale, nextBlock),
+    nextTimestamp = latestTime(),
+    rate = help.getCrowdsaleExpectedRate(crowdsale, nextTimestamp),
     tokens = command.eth * rate,
     account = accounts[command.account],
     beneficiaryAccount = accounts[command.beneficiary];
 
-  let shouldThrow = (nextBlock < startBlock) ||
-    (nextBlock > endBlock2) ||
+  let shouldThrow = (nextTimestamp < startTime) ||
+    (nextTimestamp > endTime2) ||
     (state.crowdsalePaused) ||
     (state.crowdsaleFinalized) ||
     (state.weiPerUSDinTGE == 0) ||
     (command.eth == 0);
 
   try {
-    help.debug("buyTokens rate:", rate, "eth:", command.eth, "endBlocks:", crowdsale.endBlock1, endBlock2, "blockNumber:", nextBlock);
+    help.debug("buyTokens rate:", rate, "eth:", command.eth, "endBlocks:", crowdsale.endTime1, endTime2, "blockTimestamp:", nextTimestamp);
 
     await state.crowdsaleContract.buyTokens(beneficiaryAccount, {value: weiCost, from: account});
     assert.equal(false, shouldThrow, "buyTokens should have thrown but it didn't");
@@ -85,26 +92,27 @@ let runBuyTokensCommand = async (command, state) => {
 
 let runBuyPresaleTokensCommand = async (command, state) => {
   let crowdsale = state.crowdsaleData,
-    { publicPresaleStartBlock, publicPresaleEndBlock,
-      startBlock, publicPresaleRate } = crowdsale,
+    { publicPresaleStartTime, publicPresaleEndTime,
+      startTime, publicPresaleRate } = crowdsale,
     weiCost = parseInt(web3.toWei(command.eth, 'ether')),
-    nextBlock = web3.eth.blockNumber + 1,
-    rate = help.getCrowdsaleExpectedRate(crowdsale, nextBlock),
+    nextTimestamp = latestTime(),
+    rate = help.getCrowdsaleExpectedRate(crowdsale, nextTimestamp),
     tokens = command.eth * rate,
     account = accounts[command.account],
     beneficiaryAccount = accounts[command.beneficiary],
     maxPresaleWei = crowdsale.maxPresaleCapUSD*state.weiPerUSDinPresale;
 
-  let shouldThrow = (nextBlock < publicPresaleStartBlock) ||
+  console.log('now', nextTimestamp, 'start', publicPresaleStartTime);
+  let shouldThrow = (nextTimestamp < publicPresaleStartTime) ||
     ((state.totalPresaleWei + weiCost) > maxPresaleWei) ||
-    (nextBlock > publicPresaleEndBlock) ||
+    (nextTimestamp > publicPresaleEndTime) ||
     (state.crowdsalePaused) ||
     (state.crowdsaleFinalized) ||
     (state.weiPerUSDinPresale == 0) ||
     (command.eth == 0);
 
   try {
-    help.debug("buying presale tokens, rate:", rate, "eth:", command.eth, "endBlock:", crowdsale.publicPresaleEndBlock, "blockNumber:", nextBlock);
+    help.debug("buying presale tokens, rate:", rate, "eth:", command.eth, "endBlock:", crowdsale.publicPresaleEndTime, "blockTimestamp:", nextTimestamp);
 
     await state.crowdsaleContract.buyPresaleTokens(beneficiaryAccount, {value: weiCost, from: account});
 
@@ -121,19 +129,19 @@ let runBuyPresaleTokensCommand = async (command, state) => {
 
 let runSendTransactionCommand = async (command, state) => {
   let crowdsale = state.crowdsaleData,
-    { publicPresaleStartBlock, publicPresaleEndBlock,
-      startBlock, endBlock2, publicPresaleRate,
+    { publicPresaleStartTime, publicPresaleEndTime,
+      startTime, endTime2, publicPresaleRate,
       rate1, rate2 } = crowdsale,
     weiCost = parseInt(web3.toWei(command.eth, 'ether')),
-    nextBlock = web3.eth.blockNumber + 1,
-    rate = help.getCrowdsaleExpectedRate(crowdsale, nextBlock),
+    nextTimestamp = latestTime(),
+    rate = help.getCrowdsaleExpectedRate(crowdsale, nextTimestamp),
     tokens = command.eth * rate,
     account = accounts[command.account],
     beneficiaryAccount = accounts[command.beneficiary],
     maxPresaleWei = crowdsale.maxPresaleCapUSD*state.weiPerUSDinPresale;
 
-  let inPresale = nextBlock >= publicPresaleStartBlock && nextBlock <= publicPresaleEndBlock,
-    inTGE = nextBlock >= startBlock && nextBlock <= endBlock2;
+  let inPresale = nextTimestamp >= publicPresaleStartTime && nextTimestamp <= publicPresaleEndTime,
+    inTGE = nextTimestamp >= startTime && nextTimestamp <= endTime2;
 
   let shouldThrow = (!inPresale && !inTGE) ||
     (inTGE && state.weiPerUSDinTGE == 0) ||
@@ -144,7 +152,7 @@ let runSendTransactionCommand = async (command, state) => {
     (command.eth == 0);
 
   try {
-    // help.debug("buyTokens rate:", rate, "eth:", command.eth, "endBlocks:", crowdsale.endBlock1, endBlock2, "blockNumber:", nextBlock);
+    // help.debug("buyTokens rate:", rate, "eth:", command.eth, "endBlocks:", crowdsale.endTime1, endTime2, "blockTimestamp:", nextTimestamp);
 
     await state.crowdsaleContract.sendTransaction({value: weiCost, from: account});
 
@@ -184,10 +192,10 @@ let runBurnTokensCommand = async (command, state) => {
 let runSetWeiPerUSDinPresaleCommand = async (command, state) => {
 
   let crowdsale = state.crowdsaleData,
-    { publicPresaleStartBlock, setWeiLockBlocks } = crowdsale,
-    nextBlock = web3.eth.blockNumber + 1;
+    { publicPresaleStartTime, setWeiLockBlocks } = crowdsale,
+    nextTimestamp = latestTime();
 
-  let shouldThrow = (nextBlock >= publicPresaleStartBlock-setWeiLockBlocks) ||
+  let shouldThrow = (nextTimestamp >= publicPresaleStartTime-setWeiLockBlocks) ||
     (command.fromAccount != state.owner) ||
     (command.wei == 0);
 
@@ -205,10 +213,10 @@ let runSetWeiPerUSDinPresaleCommand = async (command, state) => {
 let runSetWeiPerUSDinTGECommand = async (command, state) => {
 
   let crowdsale = state.crowdsaleData,
-    { startBlock, setWeiLockBlocks } = crowdsale,
-    nextBlock = web3.eth.blockNumber + 1;
+    { startTime, setWeiLockBlocks } = crowdsale,
+    nextTimestamp = latestTime();
 
-  let shouldThrow = (nextBlock >= startBlock-setWeiLockBlocks) ||
+  let shouldThrow = (nextTimestamp >= startTime-setWeiLockBlocks) ||
     (command.fromAccount != state.owner) ||
     (command.wei == 0);
 
@@ -263,16 +271,16 @@ let runPauseTokenCommand = async (command, state) => {
 };
 
 let runFinalizeCrowdsaleCommand = async (command, state) => {
-  let nextBlock = web3.eth.blockNumber + 1;
+  let nextTimestamp = latestTime();
   let shouldThrow = state.crowdsaleFinalized ||
     state.crowdsalePaused || (state.weiPerUSDinTGE == 0) ||
-    (web3.eth.blockNumber <= state.crowdsaleData.endBlock2);
+    (nextTimestamp <= state.crowdsaleData.endTime2);
 
   try {
 
     let crowdsaleFunded = (state.weiRaised > state.crowdsaleData.minCapUSD*state.weiPerUSDinTGE);
 
-    help.debug("finishing crowdsale on block", nextBlock, ", from address:", accounts[command.fromAccount], ", funded:", crowdsaleFunded);
+    help.debug("finishing crowdsale on block", nextTimestamp, ", from address:", accounts[command.fromAccount], ", funded:", crowdsaleFunded);
 
     let finalizeTx = await state.crowdsaleContract.finalize({from: accounts[command.fromAccount]});
 
@@ -301,20 +309,20 @@ let runFinalizeCrowdsaleCommand = async (command, state) => {
 let runAddPrivatePresalePaymentCommand = async (command, state) => {
 
   let crowdsale = state.crowdsaleData,
-    { publicPresaleStartBlock, privatePresaleRate } = crowdsale,
-    nextBlock = web3.eth.blockNumber + 1,
+    { publicPresaleStartTime, privatePresaleRate } = crowdsale,
+    nextTimestamp = latestTime(),
     weiToSend = web3.toWei(command.eth, 'ether'),
     account = accounts[command.fromAccount],
     beneficiary = accounts[command.beneficiaryAccount];
 
-  let shouldThrow = (nextBlock >= publicPresaleStartBlock) ||
+  let shouldThrow = (nextTimestamp >= publicPresaleStartTime) ||
     (state.crowdsalePaused) ||
     (account != accounts[state.owner]) ||
     (state.crowdsaleFinalized) ||
     (weiToSend == 0);
 
   try {
-    help.debug("Adding presale private tokens for account:", command.beneficiaryAccount, "eth:", command.eth, "fromAccount:", command.fromAccount, "blockNumber:", nextBlock);
+    help.debug("Adding presale private tokens for account:", command.beneficiaryAccount, "eth:", command.eth, "fromAccount:", command.fromAccount, "blockTimestamp:", nextTimestamp);
 
     await state.crowdsaleContract.addPrivatePresaleTokens(beneficiary, weiToSend, {from: account});
 
@@ -330,8 +338,8 @@ let runAddPrivatePresalePaymentCommand = async (command, state) => {
 let runClaimEthCommand = async (command, state) => {
 
   let crowdsale = state.crowdsaleData,
-    { publicPresaleStartBlock, maxPresaleWei, privatePresaleRate } = crowdsale,
-    nextBlock = web3.eth.blockNumber + 1,
+    { publicPresaleStartTime, maxPresaleWei, privatePresaleRate } = crowdsale,
+    nextTimestamp = latestTime(),
     account = accounts[command.fromAccount],
     purchases = _.filter(state.purchases, (p) => p.account == command.fromAccount);
 
@@ -438,7 +446,8 @@ let runTransferFromCommand = async (command, state) => {
 }
 
 const commands = {
-  waitBlock: {gen: gen.waitBlockCommandGen, run: runWaitBlockCommand},
+  // waitBlock: {gen: gen.waitBlockCommandGen, run: runWaitBlockCommand},
+  waitTime: {gen: gen.waitTimeCommandGen, run: runWaitTimeCommand},
   checkRate: {gen: gen.checkRateCommandGen, run: runCheckRateCommand},
   sendTransaction: {gen: gen.sendTransactionCommandGen, run: runSendTransactionCommand},
   setWeiPerUSDinPresale: {gen: gen.setWeiPerUSDinPresaleCommandGen, run: runSetWeiPerUSDinPresaleCommand},

--- a/test/generators.js
+++ b/test/generators.js
@@ -15,7 +15,7 @@ module.exports = {
     rate2: jsc.nat,
     privatePresaleRate: jsc.nat,
     foundationWallet: accountGen,
-    setWeiLockBlocks: jsc.nat(600,3600),
+    setWeiLockSeconds: jsc.nat(600,3600),
     owner: accountGen
   }),
 

--- a/test/generators.js
+++ b/test/generators.js
@@ -15,13 +15,18 @@ module.exports = {
     rate2: jsc.nat,
     privatePresaleRate: jsc.nat,
     foundationWallet: accountGen,
-    setWeiLockBlocks: jsc.nat(1,10),
+    setWeiLockBlocks: jsc.nat(600,3600),
     owner: accountGen
   }),
 
   waitBlockCommandGen: jsc.record({
     type: jsc.constant("waitBlock"),
     blocks: jsc.nat
+  }),
+
+  waitTimeCommandGen: jsc.record({
+    type: jsc.constant("waitTime"),
+    seconds: jsc.nat
   }),
 
   checkRateCommandGen: jsc.record({

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -111,18 +111,18 @@ module.exports = {
 
   getCrowdsaleExpectedRate: function(crowdsale, time) {
     let {
-      publicPresaleStartTime, publicPresaleEndTime, startTime,
-      endTime1, endTime2, publicPresaleRate, rate1, rate2 } = crowdsale;
+      publicPresaleStartTime, publicPresaleEndTime, startTimestamp,
+      end1Timestamp, end2Timestamp, publicPresaleRate, rate1, rate2 } = crowdsale;
 
     if (time < publicPresaleStartTime) {
       return 0;
     } else if (time <= publicPresaleEndTime) {
       return publicPresaleRate;
-    } else if (time < startTime) {
+    } else if (time < startTimestamp) {
       return 0;
-    } else if (time <= endTime1) {
+    } else if (time <= end1Timestamp) {
       return rate1;
-    } else if (time <= endTime2) {
+    } else if (time <= end2Timestamp) {
       return rate2;
     } else {
       return 0;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -109,18 +109,20 @@ module.exports = {
     }
   },
 
-  getCrowdsaleExpectedRate: function(crowdsale, blockNumber) {
-    let { publicPresaleStartBlock, publicPresaleEndBlock, startBlock, endBlock1, endBlock2, publicPresaleRate, rate1, rate2 } = crowdsale;
+  getCrowdsaleExpectedRate: function(crowdsale, time) {
+    let {
+      publicPresaleStartTime, publicPresaleEndTime, startTime,
+      endTime1, endTime2, publicPresaleRate, rate1, rate2 } = crowdsale;
 
-    if (blockNumber < publicPresaleStartBlock) {
+    if (time < publicPresaleStartTime) {
       return 0;
-    } else if (blockNumber <= publicPresaleEndBlock) {
+    } else if (time <= publicPresaleEndTime) {
       return publicPresaleRate;
-    } else if (blockNumber < startBlock) {
+    } else if (time < startTime) {
       return 0;
-    } else if (blockNumber <= endBlock1) {
+    } else if (time <= endTime1) {
       return rate1;
-    } else if (blockNumber <= endBlock2) {
+    } else if (time <= endTime2) {
       return rate2;
     } else {
       return 0;


### PR DESCRIPTION
* Change LifCrowdsale contract to work only with timestamps.
* Change the prop based tests for LifCrowdsale to work with timestamps.
* Using same simulateCrowdsale function form helpers on all tests.