### PR TITLE
Run all the tests in travis from a single command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,5 @@ cache:
 script:
   - set -e
   - jshint --show-non-errors test/*.js || echo "Errors in jshint ignored bc it doesn't support async/await"
-  - GEN_TESTS_QTY=20 yarn test test/LifToken.js test/Crowdsale.js test/CrowdsaleGenTest.js
-  - yarn test test/MarketMaker.js
-after_script:
+  - GEN_TESTS_QTY=20 yarn test
   - yarn run coveralls


### PR DESCRIPTION
We were running MarketMaker separately because there was a kind of random error
that was making the tests to fail sometimes and having it separate made it better.
But then we updated a few things (zeppelin, testrpc) and hopefully those random errors are gone