### PR TITLE
Expand usage of BigNumber in tests

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -137,7 +137,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         purchases: [],
         presalePurchases: [],
         claimedEth: {},
-        weiRaised: 0,
+        weiRaised: zero,
         totalPresaleWei: zero,
         crowdsalePaused: false,
         tokenPaused: true,

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -25,6 +25,8 @@ if (isNaN(GEN_TESTS_TIMEOUT))
 
 contract('LifCrowdsale Property-based test', function(accounts) {
 
+  const zero = new BigNumber(0);
+
   let crowdsaleTestInputGen = jsc.record({
     commands: jsc.array(jsc.nonshrink(commands.commandsGen)),
     crowdsale: jsc.nonshrink(gen.crowdsaleGen)
@@ -46,7 +48,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     assert.equal(_.sumBy(state.purchases, (b) => b.wei), parseFloat(await crowdsale.weiRaised()));
 
     // Check presale tokens sold
-    assert.equal(state.totalPresaleWei, parseFloat(await crowdsale.totalPresaleWei.call()));
+    state.totalPresaleWei.should.be.bignumber.equal(await crowdsale.totalPresaleWei.call());
     assert.equal(state.crowdsaleFinalized, await crowdsale.isFinalized.call());
     if (state.weiPerUSDinTGE > 0) {
       assert.equal(state.crowdsaleFunded, await crowdsale.funded());
@@ -136,7 +138,7 @@ contract('LifCrowdsale Property-based test', function(accounts) {
         presalePurchases: [],
         claimedEth: {},
         weiRaised: 0,
-        totalPresaleWei: 0,
+        totalPresaleWei: zero,
         crowdsalePaused: false,
         tokenPaused: true,
         crowdsaleFinalized: false,

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -34,18 +34,25 @@ contract('LifCrowdsale Property-based test', function(accounts) {
 
   let checkCrowdsaleState = async function(state, crowdsaleData, crowdsale) {
     assert.equal(state.crowdsalePaused, await crowdsale.paused());
-    assert.approximately(
-      _.sumBy(state.purchases, (b) => b.tokens),
-      parseFloat(help.lifWei2Lif(parseFloat(await crowdsale.tokensSold()))),
-      0.000000001
+    let tokensInPurchases = _.reduce(
+      _.map(state.purchases, (p) => p.tokens),
+      (accum, tokens) => accum.plus(tokens),
+      zero
     );
+    tokensInPurchases.should.be.bignumber.equal(help.lifWei2Lif(await crowdsale.tokensSold()));
+
     /*
      * TODO: add this and similar checks
     let inMemoryPresaleWei = web3.toWei(_.sumBy(state.presalePayments, (p) => p.amountEth), 'ether')
     assert.equal(inMemoryPresaleWei, parseInt(await crowdsale.totalPresaleWei.call()));
     */
     help.debug("checking purchases total wei, purchases:", JSON.stringify(state.purchases));
-    assert.equal(_.sumBy(state.purchases, (b) => b.wei), parseFloat(await crowdsale.weiRaised()));
+    let weiInPurchases = _.reduce(
+      _.map(state.purchases, (p) => p.wei),
+      (accum, wei) => accum.plus(wei),
+      zero
+    );
+    weiInPurchases.should.be.bignumber.equal(await crowdsale.weiRaised());
 
     // Check presale tokens sold
     state.totalPresaleWei.should.be.bignumber.equal(await crowdsale.totalPresaleWei.call());

--- a/test/LifToken.js
+++ b/test/LifToken.js
@@ -130,7 +130,7 @@ contract('LifToken', function(accounts) {
     assert.equal(2, decodedEvents.length);
     assert.equal(data, decodedEvents[1].events[3].value);
 
-    assert.equal(help.lif2LifWei(1000), await token.allowance(accounts[1], message.contract.address));
+    new BigNumber(help.lif2LifWei(1000)).should.be.bignumber.equal(await token.allowance(accounts[1], message.contract.address));
 
     await help.checkToken(token, accounts, 100, [40,30,20,10,0]);
   });

--- a/test/commands.js
+++ b/test/commands.js
@@ -183,7 +183,7 @@ let runSendTransactionCommand = async (command, state) => {
 
 let runBurnTokensCommand = async (command, state) => {
   let account = gen.getAccount(command.account),
-    balance = state.balances[command.account],
+    balance = getBalance(command.account),
     hasZeroAddress = isZeroAddress(account);
 
   let shouldThrow = state.tokenPaused ||
@@ -194,7 +194,7 @@ let runBurnTokensCommand = async (command, state) => {
     await state.token.burn(command.tokens, {from: account});
     assert.equal(false, shouldThrow, "burn should have thrown but it didn't");
 
-    state.balances[account] = balance - command.tokens;
+    state.balances[account] = balance.minus(command.tokens);
 
   } catch(e) {
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);

--- a/test/commands.js
+++ b/test/commands.js
@@ -88,8 +88,7 @@ let runBuyTokensCommand = async (command, state) => {
       {tokens: tokens, rate: rate, wei: weiCost, beneficiary: command.beneficiary, account: command.account}
     );
     state.balances[command.beneficiary] = getBalance(state, command.beneficiary).plus(help.lif2LifWei(tokens));
-    state.weiRaised += weiCost;
-
+    state.weiRaised = state.weiRaised.plus(weiCost);
   } catch(e) {
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
   }
@@ -170,7 +169,7 @@ let runSendTransactionCommand = async (command, state) => {
       state.purchases = _.concat(state.purchases,
         {tokens: tokens, rate: rate, wei: weiCost, beneficiary: command.beneficiary, account: command.account}
       );
-      state.weiRaised += weiCost;
+      state.weiRaised = state.weiRaised.plus(weiCost);
     } else if (rate == publicPresaleRate) {
       state.totalPresaleWei = state.totalPresaleWei.plus(weiCost);
     }
@@ -316,7 +315,7 @@ let runFinalizeCrowdsaleCommand = async (command, state) => {
 
     if (crowdsaleFunded) {
 
-      let marketMakerInitialBalance = state.weiRaised - (state.crowdsaleData.minCapUSD*state.weiPerUSDinTGE);
+      let marketMakerInitialBalance = state.weiRaised.minus(state.crowdsaleData.minCapUSD * state.weiPerUSDinTGE);
       let marketMakerPeriods = (marketMakerInitialBalance > (state.crowdsaleData.marketMaker24PeriodsCapUSD*state.weiPerUSDinTGE)) ? 48 : 24;
       let mmAddress = await state.crowdsaleContract.marketMaker();
       help.debug('MarketMaker contract address', mmAddress);

--- a/test/commands.js
+++ b/test/commands.js
@@ -165,13 +165,15 @@ let runSendTransactionCommand = async (command, state) => {
     await state.crowdsaleContract.sendTransaction({value: weiCost, from: account});
 
     assert.equal(false, shouldThrow, "sendTransaction should have thrown but it didn't");
-    if (rate == rate1 || rate == rate2) {
+    if (inTGE) {
       state.purchases = _.concat(state.purchases,
         {tokens: tokens, rate: rate, wei: weiCost, beneficiary: command.beneficiary, account: command.account}
       );
       state.weiRaised = state.weiRaised.plus(weiCost);
-    } else if (rate == publicPresaleRate) {
+    } else if (inPresale) {
       state.totalPresaleWei = state.totalPresaleWei.plus(weiCost);
+    } else {
+      throw(new Error("sendTransaction not in presale or TGE should have thrown"));
     }
   } catch(e) {
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);

--- a/test/commands.js
+++ b/test/commands.js
@@ -111,7 +111,7 @@ let runBuyPresaleTokensCommand = async (command, state) => {
 
   console.log('now', nextTimestamp, 'start', publicPresaleStartTimestamp);
   let shouldThrow = (nextTimestamp < publicPresaleStartTimestamp) ||
-    ((state.totalPresaleWei + weiCost) > maxPresaleWei) ||
+    (state.totalPresaleWei.plus(weiCost) > maxPresaleWei) ||
     (nextTimestamp > publicPresaleEndTimestamp) ||
     (state.crowdsalePaused) ||
     (state.crowdsaleFinalized) ||
@@ -126,7 +126,7 @@ let runBuyPresaleTokensCommand = async (command, state) => {
 
     assert.equal(false, shouldThrow, "buyPresaleTokens should have thrown but it didn't");
 
-    state.totalPresaleWei += weiCost;
+    state.totalPresaleWei = state.totalPresaleWei.plus(weiCost);
 
   } catch(e) {
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
@@ -154,7 +154,7 @@ let runSendTransactionCommand = async (command, state) => {
   let shouldThrow = (!inPresale && !inTGE) ||
     (inTGE && state.weiPerUSDinTGE == 0) ||
     (inPresale && state.weiPerUSDinPresale == 0) ||
-    (inPresale && ((state.totalPresaleWei + weiCost) > maxPresaleWei)) ||
+    (inPresale && (state.totalPresaleWei.plus(weiCost) > maxPresaleWei)) ||
     (state.crowdsalePaused) ||
     (state.crowdsaleFinalized) ||
     (command.eth == 0) ||
@@ -172,7 +172,7 @@ let runSendTransactionCommand = async (command, state) => {
       );
       state.weiRaised += weiCost;
     } else if (rate == publicPresaleRate) {
-      state.totalPresaleWei += weiCost;
+      state.totalPresaleWei = state.totalPresaleWei.plus(weiCost);
     }
   } catch(e) {
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
@@ -362,7 +362,7 @@ let runAddPrivatePresalePaymentCommand = async (command, state) => {
 
     assert.equal(false, shouldThrow, "buyTokens should have thrown but it didn't");
 
-    state.totalPresaleWei += weiToSend;
+    state.totalPresaleWei = state.totalPresaleWei.plus(weiToSend);
   } catch(e) {
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
   }

--- a/test/commands.js
+++ b/test/commands.js
@@ -183,7 +183,7 @@ let runSendTransactionCommand = async (command, state) => {
 
 let runBurnTokensCommand = async (command, state) => {
   let account = gen.getAccount(command.account),
-    balance = getBalance(command.account),
+    balance = getBalance(state, command.account),
     hasZeroAddress = isZeroAddress(account);
 
   let shouldThrow = state.tokenPaused ||

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,7 +13,6 @@ abiDecoder.addABI(LifMarketMaker._json.abi);
 var latestTime = require('./helpers/latestTime');
 var {increaseTimeTestRPC, increaseTimeTestRPCTo, duration} = require('./helpers/increaseTime');
 
-const TOKEN_DECIMALS = 18;
 const DEBUG_MODE = (process.env.WT_DEBUG == "true") || false;
 
 module.exports = {
@@ -44,19 +43,12 @@ module.exports = {
     return back;
   },
 
-  lifWei2Lif: function(balance){
-    return (balance/Math.pow(10,TOKEN_DECIMALS)).toPrecision(TOKEN_DECIMALS);
-  },
-  lif2LifWei: function(balance){
-    return (balance*Math.pow(10,TOKEN_DECIMALS));
+  lifWei2Lif: function(value){
+    return web3.fromWei(value, 'ether');
   },
 
-  toEther: function(wei){
-    return web3.fromWei(parseFloat(wei), 'ether');
-  },
-
-  toWei: function(ether){
-    return web3.toWei(parseFloat(ether), 'wei');
+  lif2LifWei: function(value){
+    return web3.toWei(value, 'ether');
   },
 
   isInvalidOpcodeEx: function(e) {


### PR DESCRIPTION
We should use BigNumber everywhere, especially when dealing with lif/eth amounts. This goes towards that direction. Also makes some minor cleanups