### PR TITLE
Tranfering ownership to foundation once the market maker is created

### DIFF
--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -258,6 +258,7 @@ contract LifCrowdsale is Ownable, Pausable {
         address(token), block.number.add(10), 20, marketMakerPeriods, foundationWallet
       );
       newMarketMaker.fund.value(mmFundBalance)();
+      newMarketMaker.transferOwnership(foundationWallet);
 
       marketMaker = address(newMarketMaker);
 

--- a/test/commands.js
+++ b/test/commands.js
@@ -295,6 +295,7 @@ let runFinalizeCrowdsaleCommand = async (command, state) => {
 
       assert.equal(24, parseInt(await marketMaker.totalPeriods()));
       assert.equal(state.crowdsaleData.foundationWallet, await marketMaker.foundationAddr());
+      assert.equal(state.crowdsaleData.foundationWallet, await marketMaker.owner());
 
       state.marketMaker = marketMaker;
     }


### PR DESCRIPTION
Tranfering ownership to foundation once the market maker is created and funded from the crowdsale.