### PR TITLE
Add fund and finalize crowdsale composed command in property-based test

### DIFF
--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -238,7 +238,7 @@ contract LifCrowdsale is Ownable, Pausable {
 
     // if the minimiun cap for the market maker is not reached transfer all funds to foundation
     // else if the min cap for the market maker is reached, create it and send the remaining funds
-    if (this.balance < foundationBalanceCapWei) {
+    if (this.balance <= foundationBalanceCapWei) {
 
       foundationWallet.transfer(this.balance);
 

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -337,6 +337,18 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     });
   });
 
+  it("should run the fund and finalize crowdsale command fine", async function() {
+    await runGeneratedCrowdsaleAndCommands({
+      commands: [
+        {"type":"fundCrowdsaleBelowSoftCap","account":3,"finalize":true}
+      ],
+      crowdsale: {
+        publicPresaleRate: 41, rate1: 20, rate2: 46, privatePresaleRate: 0,
+        foundationWallet: 4, setWeiLockSeconds: 521, owner: 0
+      }
+    });
+  });
+
   it("distributes tokens correctly on any combination of bids", async function() {
     // stateful prob based tests can take a long time to finish when shrinking...
     this.timeout(GEN_TESTS_TIMEOUT * 1000);

--- a/test/commands.js
+++ b/test/commands.js
@@ -309,13 +309,16 @@ let runFinalizeCrowdsaleCommand = async (command, state) => {
 
   try {
 
-    let crowdsaleFunded = (state.weiRaised > state.crowdsaleData.minCapUSD*state.weiPerUSDinTGE);
+    let crowdsaleFunded = (state.weiRaised >= state.crowdsaleData.minCapUSD*state.weiPerUSDinTGE);
 
     help.debug("finishing crowdsale on block", nextTimestamp, ", from address:", gen.getAccount(command.fromAccount), ", funded:", crowdsaleFunded);
 
     let finalizeTx = await state.crowdsaleContract.finalize({from: account});
 
-    if (crowdsaleFunded) {
+    let fundsRaised = state.weiRaised.div(state.weiPerUSDinTGE),
+      minimumForMarketMaker = await state.crowdsaleContract.maxFoundationCapUSD;
+
+    if (crowdsaleFunded && (fundsRaised > minimumForMarketMaker)) {
 
       let marketMakerInitialBalance = state.weiRaised.minus(state.crowdsaleData.minCapUSD * state.weiPerUSDinTGE);
       let marketMakerPeriods = (marketMakerInitialBalance > (state.crowdsaleData.marketMaker24PeriodsCapUSD*state.weiPerUSDinTGE)) ? 48 : 24;

--- a/test/commands.js
+++ b/test/commands.js
@@ -512,6 +512,55 @@ let getMMMaxClaimableWei = function(state) {
   }
 }
 
+let runFundCrowdsaleBelowSoftCap = async (command, state) => {
+  if (!state.crowdsaleFinalized) {
+    // unpause the crowdsale if needed
+    if (state.crowdsalePaused) {
+      state = await runPauseCrowdsaleCommand({pause: false, fromAccount: state.owner}, state);
+    }
+
+    // set weiPerUSDinTGE rate if needed
+    if (state.weiPerUSDinTGE == 0) {
+      state = await runSetWeiPerUSDinTGECommand({wei: 10000, fromAccount: state.owner}, state);
+    }
+
+    let minCapUSD = await state.crowdsaleContract.minCapUSD.call(),
+      currentUSDFunding = state.weiRaised.div(state.weiPerUSDinTGE);
+
+    if (minCapUSD > currentUSDFunding) {
+      // wait for crowdsale startTimestamp
+      if (latestTime() < state.crowdsaleData.startTimestamp) {
+        await increaseTimeTestRPCTo(state.crowdsaleData.startTimestamp);
+      }
+
+      // buy enough tokens to exactly reach the minCap (which is less than softCap)
+      let wei = minCapUSD.minus(currentUSDFunding).mul(state.weiPerUSDinTGE),
+        eth = web3.fromWei(wei, 'ether'),
+        buyTokensCommand = {account: command.account, eth: eth, beneficiary: command.account};
+
+      state = await runBuyTokensCommand(buyTokensCommand, state);
+    }
+
+    minCapUSD.should.be.bignumber.equal(new BigNumber(state.weiRaised).div(state.weiPerUSDinTGE));
+
+    if (command.finalize) {
+      // wait for crowdsale end2Timestamp
+      if (latestTime() < state.crowdsaleData.end2Timestamp) {
+        await increaseTimeTestRPCTo(state.crowdsaleData.end2Timestamp + 1);
+      }
+
+      state = await runFinalizeCrowdsaleCommand({fromAccount: command.account}, state);
+
+      // verify that the crowdsale is finalized and funded, but there's no market maker
+      assert.equal(true, state.crowdsaleFinalized);
+      assert.equal(true, state.crowdsaleFunded);
+      assert(state.marketMaker === undefined);
+    }
+  }
+
+  return state;
+}
+
 // TODO: implement finished
 let isMarketMakerFinished = (state) => false
 
@@ -581,6 +630,7 @@ const commands = {
   transfer: {gen: gen.transferCommandGen, run: runTransferCommand},
   approve: {gen: gen.approveCommandGen, run: runApproveCommand},
   transferFrom: {gen: gen.transferFromCommandGen, run: runTransferFromCommand},
+  fundCrowdsaleBelowSoftCap: {gen: gen.fundCrowdsaleBelowSoftCap, run: runFundCrowdsaleBelowSoftCap},
   marketMakerSendTokens: {gen: gen.marketMakerSendTokensCommandGen, run: runMarketMakerSendTokensCommand}
 };
 

--- a/test/generators.js
+++ b/test/generators.js
@@ -144,5 +144,11 @@ module.exports = {
     from: accountGen
   }),
 
+  fundCrowdsaleBelowSoftCap: jsc.record({
+    type: jsc.constant("fundCrowdsaleBelowSoftCap"),
+    account: knownAccountGen, // we don't want this one to fail with 0x0 addresses
+    finalize: jsc.bool
+  }),
+
 }
 


### PR DESCRIPTION
funds the crowdsale for the amount remaining until the min cap and finalizes it. This way there's more chance the tests will also run on a finalized and funded crowdsale. Next step is to add a similar command to fund it until the market maker minimum