### PR TITLE
Fix test example on fund below cap command

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -216,6 +216,15 @@ contract('LifCrowdsale Property-based test', function(accounts) {
       }
     });
 
+    await runGeneratedCrowdsaleAndCommands({
+      commands: [
+        {"type":"fundCrowdsaleBelowSoftCap","account":7,"finalize":false}
+      ],
+      crowdsale: {
+        publicPresaleRate: 5, rate1: 33, rate2: 12, privatePresaleRate: 28,
+        foundationWallet: 10, setWeiLockSeconds: 52, owner: 0
+      }
+    });
   });
 
   it("calculates correct rate on the boundaries between end1Timestamp and end2Timestamp", async function() {

--- a/test/commands.js
+++ b/test/commands.js
@@ -65,7 +65,7 @@ let runBuyTokensCommand = async (command, state) => {
     weiCost = parseInt(web3.toWei(command.eth, 'ether')),
     nextTimestamp = latestTime(),
     rate = help.getCrowdsaleExpectedRate(crowdsale, nextTimestamp),
-    tokens = command.eth * rate,
+    tokens = new BigNumber(command.eth).mul(rate),
     account = gen.getAccount(command.account),
     beneficiaryAccount = gen.getAccount(command.beneficiary),
     hasZeroAddress = _.some([account, beneficiaryAccount], isZeroAddress);
@@ -142,7 +142,7 @@ let runSendTransactionCommand = async (command, state) => {
     weiCost = parseInt(web3.toWei(command.eth, 'ether')),
     nextTimestamp = latestTime(),
     rate = help.getCrowdsaleExpectedRate(crowdsale, nextTimestamp),
-    tokens = command.eth * rate,
+    tokens = new BigNumber(command.eth).mul(rate),
     account = gen.getAccount(command.account),
     maxPresaleWei = crowdsale.maxPresaleCapUSD*state.weiPerUSDinPresale;
 


### PR DESCRIPTION
Uses BigNumber to avoid the errors due to too many decimals with primitive numbers. Error was

```
BigNumber Error: plus() number type has more than 15 significant digits: 0.0000016499999999999999
```