### PR TITLE
Do not use zero address to create crowdsale in prop-based tests

### DIFF
--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -34,7 +34,7 @@ contract('LifToken Crowdsale', function(accounts) {
       end2Timestamp = startTimestamp + duration.days(2);
 
     try {
-      let crowdsale = await LifCrowdsale.new(
+      await LifCrowdsale.new(
         startTimestamp, end1Timestamp, end2Timestamp,
         100, 110, duration.minutes(30), help.zeroAddress
       );

--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -1,5 +1,7 @@
 var LifCrowdsale = artifacts.require('./LifCrowdsale.sol');
 
+let help = require('./helpers');
+
 var latestTime = require('./helpers/latestTime');
 var {duration} = require('./helpers/increaseTime');
 
@@ -26,4 +28,19 @@ contract('LifToken Crowdsale', function(accounts) {
 
   });
 
+  it('fails to create a Crowndsale with 0x0 as foundation wallet', async function() {
+    const startTimestamp = latestTime() + duration.days(1),
+      end1Timestamp = startTimestamp + duration.days(1),
+      end2Timestamp = startTimestamp + duration.days(2);
+
+    try {
+      let crowdsale = await LifCrowdsale.new(
+        startTimestamp, end1Timestamp, end2Timestamp,
+        100, 110, duration.minutes(30), help.zeroAddress
+      );
+      assert(false, 'create crowdsale should have thrown');
+    } catch(e) {
+      if (!help.isInvalidOpcodeEx(e)) throw e;
+    }
+  });
 });

--- a/test/generators.js
+++ b/test/generators.js
@@ -26,9 +26,9 @@ module.exports = {
   crowdsaleGen: jsc.record({
     rate1: jsc.nat,
     rate2: jsc.nat,
-    foundationWallet: accountGen,
+    foundationWallet: knownAccountGen,
     setWeiLockSeconds: jsc.integer(600,3600),
-    owner: accountGen
+    owner: knownAccountGen
   }),
 
   waitBlockCommandGen: jsc.record({


### PR DESCRIPTION
It creates too many test that don't even get to create the crowdsale. Better to have a
test for that specific example and run the tests with commands with at least the
crowdsale created successfully