### PR TITLE
Fix approve and transferFrom commands

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -374,6 +374,21 @@ contract('LifCrowdsale Property-based test', function() {
     });
   });
 
+  it('should approve from zero spender address with lif amount > 0, and then transferFrom', async function() {
+    await runGeneratedCrowdsaleAndCommands({
+      commands:
+      [
+        {'type':'fundCrowdsaleOverSoftCap','account':10,'softCapExcessWei':25,'finalize':true},
+        {'type':'approve','lif':23,'fromAccount':10,'spenderAccount':'zero'},
+        {'type':'transferFrom','lif':23,'fromAccount':'zero','toAccount':5,'senderAccount':10}
+      ],
+      crowdsale: {
+        rate1: 23, rate2: 16, foundationWallet: 0,
+        setWeiLockSeconds: 1726, owner: 0
+      }
+    });
+  });
+
   it('should be able to transfer tokens in unpaused token after crowdsale funded over cap', async function() {
     await runGeneratedCrowdsaleAndCommands({
       commands: [

--- a/test/commands.js
+++ b/test/commands.js
@@ -402,7 +402,8 @@ async function runApproveCommand(command, state) {
     spenderAddress = gen.getAccount(command.spenderAccount),
     lifWei = help.lif2LifWei(command.lif),
     currentAllowance = getAllowance(state, command.fromAccount, command.spenderAccount),
-    shouldThrow = state.tokenPaused ||
+    hasZeroAddress = isZeroAddress(fromAddress),
+    shouldThrow = state.tokenPaused || hasZeroAddress ||
       ((lifWei != 0) && (currentAllowance != 0));
 
   try {
@@ -413,7 +414,7 @@ async function runApproveCommand(command, state) {
     // TODO: take spent gas into account?
     setAllowance(state, command.fromAccount, command.spenderAccount, lifWei);
   } catch(e) {
-    assertExpectedException(e, shouldThrow, false, state, command);
+    assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
   }
   return state;
 }
@@ -425,7 +426,7 @@ async function runTransferFromCommand(command, state) {
     toAddress = gen.getAccount(command.toAccount),
     fromBalance = getBalance(state, command.fromAccount),
     lifWei = help.lif2LifWei(command.lif),
-    hasZeroAddress = isZeroAddress(toAddress),
+    hasZeroAddress = _.some([senderAddress, toAddress], isZeroAddress),
     allowance = getAllowance(state, command.senderAccount, command.fromAccount);
 
   let shouldThrow = state.tokenPaused ||


### PR DESCRIPTION
Both commands don't need to check for address 0x0 as the from/sender
address. Only the transferFrom has to check for address 0x0 in the 
to address

Fixes #205