### PR TITLE
Fix fund over soft cap command with some funding before it runs

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -427,6 +427,19 @@ contract('LifCrowdsale Property-based test', function() {
     });
   });
 
+  it('should run the fund and finalize below and over soft cap sequence fine', async function() {
+    await runGeneratedCrowdsaleAndCommands({
+      commands: [
+        {'type':'fundCrowdsaleBelowSoftCap','account':3,'finalize':false},
+        {'type':'fundCrowdsaleOverSoftCap','account':10,'softCapExcessWei':15,'finalize':false}
+      ],
+      crowdsale: {
+        rate1: 26, rate2: 28, foundationWallet: 9,
+        setWeiLockSeconds: 2696, owner: 6
+      }
+    });
+  });
+
   it('distributes tokens correctly on any combination of bids', async function() {
     // stateful prob based tests can take a long time to finish when shrinking...
     this.timeout(GEN_TESTS_TIMEOUT * 1000);

--- a/test/commands.js
+++ b/test/commands.js
@@ -564,7 +564,8 @@ async function runFundCrowdsaleOverSoftCap(command, state) {
 
       state = await runBuyTokensCommand(buyTokensCommand, state);
 
-      wei.should.be.bignumber.equal(state.weiRaised);
+      softCap.mul(state.weiPerUSDinTGE).plus(command.softCapExcessWei).
+        should.be.bignumber.equal(state.weiRaised);
     }
 
     if (command.finalize) {


### PR DESCRIPTION
For example a sequence of fund below cap (without finalize) and a fund over cap was making the second one to fail this assert because there was some previous funding in the crowdsale already