### PR TITLE
Property-based tests: improve output to make it easier to reproduce failures

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -154,7 +154,11 @@ contract('LifCrowdsale Property-based test', function() {
           help.debug('An error occurred, block timestamp: ' + latestTime() + '\nError: ' + error);
           if (error instanceof commands.ExceptionRunningCommand) {
             throw(new Error('command ' + JSON.stringify(commandParams) + ' has thrown.'
-              + '\nError: ' + error.error));
+              + '\nError: ' + error.error
+              + '\n\nUse the following to reproduce the failure:\n\n'
+              + 'await runGeneratedCrowdsaleAndCommands('
+              + JSON.stringify(input, null, 2) + ');'
+            ));
           } else
             throw(error);
         }


### PR DESCRIPTION
When a failure is found in the property-based tests, it's useful to grab the failed example and construct a specific test for that example. This makes it easier by generating the code that makes the body of that example

### Example output, before:

```js
  1) Contract: LifCrowdsale Property-based test should fund and finalize over cap and then send tokens to MVM fine:
     Error: command {"type":"MVMSendTokens","tokens":4,"from":4} has thrown.
Error: Error: VM Exception while processing transaction: invalid opcode
      at runGeneratedCrowdsaleAndCommands (test/CrowdsaleGenTest.js:156:19)
      at process._tickCallback (internal/process/next_tick.js:109:7)
```

### Example output, after:

```js
  1) Contract: LifCrowdsale Property-based test should fund and finalize over cap and then send tokens to MVM fine:
     Error: command {"type":"MVMSendTokens","tokens":4,"from":4} has thrown.
Error: Error: VM Exception while processing transaction: invalid opcode
Use the following to reproduce the failure:

await runGeneratedCrowdsaleAndCommands({
  "commands": [
    {
      "type": "fundCrowdsaleOverSoftCap",
      "account": 0,
      "softCapExcessWei": 32,
      "finalize": true
    },
    {
      "type": "MVMSendTokens",
      "tokens": 4,
      "from": 4
    }
  ],
  "crowdsale": {
    "rate1": 2,
    "rate2": 32,
    "foundationWallet": 7,
    "setWeiLockSeconds": 2098,
    "owner": 9
  }
});
      at runGeneratedCrowdsaleAndCommands (test/CrowdsaleGenTest.js:156:19)
      at process._tickCallback (internal/process/next_tick.js:109:7)
```