### PR TITLE
More MVM property-based tests

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -457,6 +457,19 @@ contract('LifCrowdsale Property-based test', function() {
     });
   });
 
+  it('should fund and finalize over cap and then send tokens to MVM fine', async function() {
+    await runGeneratedCrowdsaleAndCommands({
+      commands: [
+        {'type':'fundCrowdsaleOverSoftCap','account':0,'softCapExcessWei':32,'finalize':true},
+        {'type':'MVMSendTokens','tokens':4,'from':4}
+      ],
+      crowdsale: {
+        rate1: 2, rate2: 32, foundationWallet: 7,
+        setWeiLockSeconds: 2098, owner: 9
+      }
+    });
+  });
+
   it('runs the fund over soft cap and finalize with 0 excess command fine', async function() {
     await runGeneratedCrowdsaleAndCommands({
       commands: [

--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -140,8 +140,11 @@ contract('LifCrowdsale Property-based test', function() {
         crowdsaleFunded: false,
         owner: owner,
         totalSupply: zero,
+        initialTokenSupply: zero,
         MVMBuyPrice: new BigNumber(0),
         MVMBurnedTokens: new BigNumber(0),
+        MVMClaimedWei: zero,
+        claimablePercentage: zero,
         burnedTokens: zero,
         returnedWeiForBurnedTokens: new BigNumber(0)
       };
@@ -491,6 +494,15 @@ contract('LifCrowdsale Property-based test', function() {
       'crowdsale': {
         'rate1': 23, 'rate2': 40, 'foundationWallet': 1,
         'setWeiLockSeconds': 1445, 'owner': 2
+      }
+    });
+
+    await runGeneratedCrowdsaleAndCommands({
+      commands: [
+        {'type':'fundCrowdsaleOverSoftCap','account':7,'softCapExcessWei':13,'finalize':true},
+        {'type':'MVMClaimEth','eth':12}
+      ],
+      crowdsale: {rate1: 3, rate2: 11, foundationWallet: 5, setWeiLockSeconds: 3152, owner: 10
       }
     });
   });

--- a/test/commands.js
+++ b/test/commands.js
@@ -456,31 +456,11 @@ async function runTransferFromCommand(command, state) {
   return state;
 }
 
-
 //
-// Market Maker commands
+// Composed commands
 //
-
-let getMvmMaxClaimableWei = function(state) {
-  if (state.MVMMonth >= state.MVMPeriods) {
-    help.debug('calculating maxClaimableEth with', state.MVMStartingBalance,
-      state.MVMClaimedWei,
-      state.returnedWeiForBurnedTokens);
-    return state.MVMStartingBalance.
-      minus(state.MVMClaimedWei).
-      minus(state.returnedWeiForBurnedTokens);
-  } else {
-    const maxClaimable = state.MVMStartingBalance.
-      mul(state.claimablePercentage).dividedBy(priceFactor).
-      mul(state.initialTokenSupply - state.MVMBurnedTokens).
-      dividedBy(state.initialTokenSupply).
-      minus(state.MVMClaimedWei);
-    return _.max([0, maxClaimable]);
-  }
-};
 
 async function startCrowdsaleAndBuyTokens(account, eth, weiPerUSD, state) {
-
   // unpause the crowdsale if needed
   if (state.crowdsalePaused) {
     state = await runPauseCrowdsaleCommand({pause: false, fromAccount: state.owner}, state);
@@ -632,6 +612,28 @@ async function runFundCrowdsaleOverSoftCap(command, state) {
 
   return state;
 }
+
+//
+// Market Maker commands
+//
+
+let getMvmMaxClaimableWei = function(state) {
+  if (state.MVMMonth >= state.MVMPeriods) {
+    help.debug('calculating maxClaimableEth with', state.MVMStartingBalance,
+      state.MVMClaimedWei,
+      state.returnedWeiForBurnedTokens);
+    return state.MVMStartingBalance.
+      minus(state.MVMClaimedWei).
+      minus(state.returnedWeiForBurnedTokens);
+  } else {
+    const maxClaimable = state.MVMStartingBalance.
+      mul(state.claimablePercentage).dividedBy(priceFactor).
+      mul(state.initialTokenSupply - state.MVMBurnedTokens).
+      dividedBy(state.initialTokenSupply).
+      minus(state.MVMClaimedWei);
+    return _.max([0, maxClaimable]);
+  }
+};
 
 // TODO: implement finished, returns false, but references state to make eslint happy
 let isMVMFinished = (state) => state && false;

--- a/test/commands.js
+++ b/test/commands.js
@@ -621,7 +621,7 @@ async function runFundCrowdsaleOverSoftCap(command, state) {
 // Market Maker commands
 //
 
-let getMvmMaxClaimableWei = function(state) {
+let getMVMMaxClaimableWei = function(state) {
   if (state.MVMMonth >= state.MVMPeriods) {
     help.debug('calculating maxClaimableEth with', state.MVMStartingBalance,
       state.MVMClaimedWei,
@@ -646,7 +646,7 @@ async function runMVMClaimEthCommand(command, state) {
   if (state.MVM !== undefined) {
     let weiToClaim = web3.toWei(command.eth),
       hasZeroAddress = false,
-      shouldThrow = (weiToClaim > getMvmMaxClaimableWei(state));
+      shouldThrow = (weiToClaim > getMVMMaxClaimableWei(state));
 
     try {
       help.debug('Claiming ', weiToClaim.toString(), 'wei (', command.eth.toString(), 'eth)');
@@ -654,7 +654,7 @@ async function runMVMClaimEthCommand(command, state) {
 
       state.MVMClaimedWei = state.MVMClaimedWei.plus(weiToClaim);
       state.MVMEthBalance = state.MVMEthBalance.minus(weiToClaim);
-      state.MVMMaxClaimableWei = getMvmMaxClaimableWei(state);
+      state.MVMMaxClaimableWei = getMVMMaxClaimableWei(state);
     } catch(e) {
       assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
     }
@@ -706,7 +706,7 @@ async function runMVMSendTokensCommand(command, state) {
       state.MVMBurnedTokens = state.MVMBurnedTokens.plus(lifWei);
       state.returnedWeiForBurnedTokens = state.returnedWeiForBurnedTokens.plus(tokensCost);
       state.balances[command.from] = getBalance(state, command.from).minus(lifWei);
-      state.MVMMaxClaimableWei = getMvmMaxClaimableWei(state);
+      state.MVMMaxClaimableWei = getMVMMaxClaimableWei(state);
 
     } catch(e) {
       assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
@@ -757,7 +757,7 @@ async function runMVMWaitForMonthCommand(command, state) {
       mul(priceFactor - state.claimablePercentage).
       dividedBy(priceFactor).floor();
     state.MVMMonth = command.month;
-    state.MVMMaxClaimableWei = getMvmMaxClaimableWei(state);
+    state.MVMMaxClaimableWei = getMVMMaxClaimableWei(state);
   }
 
   return state;
@@ -797,7 +797,5 @@ module.exports = {
     return command;
   },
 
-  ExceptionRunningCommand: ExceptionRunningCommand,
-
-  getMvmMaxClaimableWei: getMvmMaxClaimableWei
+  ExceptionRunningCommand: ExceptionRunningCommand
 };

--- a/test/commands.js
+++ b/test/commands.js
@@ -461,7 +461,7 @@ async function runTransferFromCommand(command, state) {
 // Market Maker commands
 //
 
-let getMMMaxClaimableWei = function(state) {
+let getMvmMaxClaimableWei = function(state) {
   if (state.MVMMonth >= state.MVMPeriods) {
     help.debug('calculating maxClaimableEth with', state.MVMStartingBalance,
       state.MVMClaimedWei,
@@ -679,7 +679,7 @@ async function runMVMSendTokensCommand(command, state) {
       state.MVMBurnedTokens = state.MVMBurnedTokens.plus(lifWei);
       state.returnedWeiForBurnedTokens = state.returnedWeiForBurnedTokens.plus(tokensCost);
       state.balances[command.from] = getBalance(state, command.from).minus(lifWei);
-      state.MVMMaxClaimableWei = getMMMaxClaimableWei(state);
+      state.MVMMaxClaimableWei = getMvmMaxClaimableWei(state);
 
     } catch(e) {
       assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);
@@ -722,5 +722,7 @@ module.exports = {
     return command;
   },
 
-  ExceptionRunningCommand: ExceptionRunningCommand
+  ExceptionRunningCommand: ExceptionRunningCommand,
+
+  getMvmMaxClaimableWei: getMvmMaxClaimableWei
 };

--- a/test/commands.js
+++ b/test/commands.js
@@ -652,12 +652,14 @@ async function runMVMSendTokensCommand(command, state) {
       lifBuyPrice = state.MVMBuyPrice.div(priceFactor),
       tokensCost = new BigNumber(lifWei).mul(lifBuyPrice),
       fromAddress = gen.getAccount(command.from),
+      lifBalanceBeforeSend = getBalance(state, command.from),
       ethBalanceBeforeSend = state.ethBalances[command.from] || new BigNumber(0),
       hasZeroAddress = isZeroAddress(fromAddress);
 
     let shouldThrow = !state.crowdsaleFinalized ||
       !state.crowdsaleFunded ||
       state.MVMPaused ||
+      (lifWei > lifBalanceBeforeSend) ||
       (command.tokens == 0) ||
       isMVMFinished(state) ||
       hasZeroAddress;

--- a/test/commands.js
+++ b/test/commands.js
@@ -281,6 +281,9 @@ async function runFinalizeCrowdsaleCommand(command, state) {
       state.totalSupply = state.totalSupply.plus(foundersVestingTokens).
         plus(longTermReserve).plus(teamTokens);
 
+      // used for some MVM calculations
+      state.initialTokenSupply = state.totalSupply;
+
       if (fundsRaised.gt(minimumForMVM)) {
 
         let MVMInitialBalance = state.weiRaised.minus(state.crowdsaleData.minCapUSD * state.weiPerUSDinTGE);
@@ -296,6 +299,7 @@ async function runFinalizeCrowdsaleCommand(command, state) {
 
         state.MVM = MVM;
         state.MVMStartTimestamp = nextTimestamp + duration.days(30);
+        state.MVMStartingBalance = MVMInitialBalance;
         state.MVMInitialBuyPrice = MVMInitialBalance.
           mul(priceFactor).
           dividedBy(help.lif2LifWei(state.totalSupply)).floor();

--- a/test/generators.js
+++ b/test/generators.js
@@ -130,6 +130,11 @@ module.exports = {
     from: accountGen
   }),
 
+  MVMClaimEthCommandGen: jsc.record({
+    type: jsc.constant('MVMClaimEth'),
+    eth: jsc.nat
+  }),
+
   fundCrowdsaleBelowMinCap: jsc.record({
     type: jsc.constant('fundCrowdsaleBelowSoftCap'),
     account: knownAccountGen, // we don't want this one to fail with 0x0 addresses

--- a/test/generators.js
+++ b/test/generators.js
@@ -135,6 +135,11 @@ module.exports = {
     eth: jsc.nat
   }),
 
+  MVMWaitForMonthCommandGen: jsc.record({
+    type: jsc.constant('MVMWaitForMonth'),
+    month: jsc.nat
+  }),
+
   fundCrowdsaleBelowMinCap: jsc.record({
     type: jsc.constant('fundCrowdsaleBelowSoftCap'),
     account: knownAccountGen, // we don't want this one to fail with 0x0 addresses


### PR DESCRIPTION
Adds a specific example that was failing, refactors the MVM tests by adding its commands as property-based test commands in `commands.js`

Fixes #156 