### PR TITLE
Add message to ExceptionRunningCommand

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -153,9 +153,8 @@ contract('LifCrowdsale Property-based test', function() {
         catch(error) {
           help.debug('An error occurred, block timestamp: ' + latestTime() + '\nError: ' + error);
           if (error instanceof commands.ExceptionRunningCommand) {
-            throw(new Error('command ' + JSON.stringify(commandParams) + ' has thrown.'
-              + '\nError: ' + error.error
-              + '\n\nUse the following to reproduce the failure:\n\n'
+            throw(new Error(
+              error.message + '\n\nUse the following to reproduce the failure:\n\n'
               + 'await runGeneratedCrowdsaleAndCommands('
               + JSON.stringify(input, null, 2) + ');'
             ));

--- a/test/commands.js
+++ b/test/commands.js
@@ -37,6 +37,7 @@ function ExceptionRunningCommand(e, state, command) {
   this.error = e;
   this.state = state;
   this.command = command;
+  this.message = 'command ' + JSON.stringify(command) + ' has thrown.' + '\nError: ' + e;
 }
 
 ExceptionRunningCommand.prototype = Object.create(Error.prototype);


### PR DESCRIPTION
Shows that message when the exception is thrown when using the command not from CrowdsaleGenTest (in that case the message was being shown explicitly from the exception handler there, now it would show when used from anywhere)