### PR TITLE
Add a commented out mocha option to show how to pass such options

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -26,5 +26,9 @@ module.exports = {
       gas: 0xfffffffffff,
       gasPrice: 0x01
     }
+  },
+  mocha: {
+    // a commented out mocha option, shows how to pass mocha options
+    // bail: true  // bail makes mocha to stop as soon as a test failure is found
   }
 };


### PR DESCRIPTION
Uses bail as example, which allows to stop test runs as soon as the first failure is found, useful during development

I'm not sure if this is the best way to do this. I didn't know about this option or even how to pass options to mocha. AFAIK the possible options are shown [here](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options) and explanations can be obtained running `./node_modules/.bin/mocha --help`

I don't think this should be put in the README, it's too specific to running the tests. It is in [truffle docs](http://truffleframework.com/docs/advanced/configuration#mocha) but I don't think it's very visible/easy to find.

What do you think @AugustoL? Feel 100% free to close it or merge it :)