### PR TITLE
Fix MVMClaimEth command: use bignumber gt

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -634,6 +634,20 @@ contract('LifCrowdsale Property-based test', function() {
     });
   });
 
+  it('can fund over soft cap, wait a few months and then claim eth on the mvm', async function() {
+    await runGeneratedCrowdsaleAndCommands({
+      'commands': [
+        { 'type': 'fundCrowdsaleOverSoftCap', 'account': 2, 'softCapExcessWei': 8, 'finalize': true },
+        { 'type': 'MVMWaitForMonth', 'month': 11 },
+        { 'type': 'MVMClaimEth', 'eth': 4 }
+      ],
+      'crowdsale': {
+        'rate1': 5, 'rate2': 1, 'foundationWallet': 5, 'foundersWallet': 2,
+        'setWeiLockSeconds': 3214, 'owner': 7
+      }
+    });
+  });
+
   it('distributes tokens correctly on any combination of bids', async function() {
     // stateful prob based tests can take a long time to finish when shrinking...
     this.timeout(GEN_TESTS_TIMEOUT * 1000);

--- a/test/commands.js
+++ b/test/commands.js
@@ -640,7 +640,8 @@ let getMVMMaxClaimableWei = function(state) {
       mul(state.initialTokenSupply - state.MVMBurnedTokens).
       dividedBy(state.initialTokenSupply).
       minus(state.MVMClaimedWei);
-    return _.max([0, maxClaimable]);
+
+    return maxClaimable.gt(0) ? maxClaimable : new BigNumber(0);
   }
 };
 

--- a/test/commands.js
+++ b/test/commands.js
@@ -652,7 +652,7 @@ async function runMVMClaimEthCommand(command, state) {
     let weiToClaim = web3.toWei(command.eth),
       hasZeroAddress = false;
 
-    let shouldThrow = (weiToClaim > getMVMMaxClaimableWei(state)) ||
+    let shouldThrow = getMVMMaxClaimableWei(state).lt(weiToClaim) ||
       state.MVMMonth < 0 ||
       state.MVMPaused;
 


### PR DESCRIPTION
Instead of using the comparison operators (>, <, etc), we have to use BigNumber's gt, lt, etc