### PR TITLE
Remove indexed from value param in Burn event

### DIFF
--- a/contracts/LifToken.sol
+++ b/contracts/LifToken.sol
@@ -139,6 +139,6 @@ contract LifToken is MintableToken, Pausable {
     Burn(burner, _value);
   }
 
-  event Burn(address indexed burner, uint indexed value);
+  event Burn(address indexed burner, uint value);
 
 }


### PR DESCRIPTION
It's not very useful, and this way we save some gas

Thanks to CoinFabrik for reporting this issue in their audit