### PR TITLE
Do not use this.balance in LifCrowdsale to check cap

### DIFF
--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -276,7 +276,7 @@ contract LifCrowdsale is Ownable, Pausable {
 
     // if the minimiun cap for the MVM is not reached transfer all funds to foundation
     // else if the min cap for the MVM is reached, create it and send the remaining funds
-    if (this.balance <= foundationBalanceCapWei) {
+    if (weiRaised <= foundationBalanceCapWei) {
 
       foundationWallet.transfer(this.balance);
 


### PR DESCRIPTION
We can just use weiRaised instead. Then we can use this.balance to do
the actual transfer of funds, to include any remaining funds. But to
check against the cap, weiRaised is fine

Fixes #245