### PR TITLE
Convert some methods to modifiers

### DIFF
--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -213,9 +213,8 @@ contract LifCrowdsale is Ownable, Pausable {
 
      @param beneficiary Address to which Lif should be sent
    */
-  function buyTokens(address beneficiary) public payable {
+  function buyTokens(address beneficiary) public payable validPurchase {
     require(beneficiary != address(0));
-    require(validPurchase());
     assert(weiPerUSDinTGE > 0);
 
     uint256 weiAmount = msg.value;
@@ -345,17 +344,19 @@ contract LifCrowdsale is Ownable, Pausable {
 
   /**
      @dev Modifier
-     @return true if the transaction can buy tokens on TGE
+     ok if the transaction can buy tokens on TGE
    */
-  function validPurchase() internal constant returns (bool) {
+  modifier validPurchase() {
     bool withinPeriod = now >= startTimestamp && now <= end2Timestamp;
     bool nonZeroPurchase = msg.value != 0;
-    return (withinPeriod && nonZeroPurchase);
+    assert(withinPeriod && nonZeroPurchase);
+
+    _;
   }
 
   /**
      @dev Modifier
-     throws when block.timestamp is not past end2Timestamp
+     ok when block.timestamp is past end2Timestamp
   */
   modifier hasEnded() {
     assert(block.timestamp > end2Timestamp);

--- a/contracts/LifCrowdsale.sol
+++ b/contracts/LifCrowdsale.sol
@@ -355,10 +355,11 @@ contract LifCrowdsale is Ownable, Pausable {
 
   /**
      @dev Modifier
-     @return true if crowdsale event has ended
+     throws when block.timestamp is not past end2Timestamp
   */
-  function hasEnded() public constant returns (bool) {
-    return block.timestamp > end2Timestamp;
+  modifier hasEnded() {
+    assert(block.timestamp > end2Timestamp);
+    _;
   }
 
   /**
@@ -374,9 +375,8 @@ contract LifCrowdsale is Ownable, Pausable {
      @dev Allows a TGE contributor to claim their contributed eth in case the
      TGE has finished without reaching the minCapUSD
    */
-  function claimEth() public {
+  function claimEth() public hasEnded {
     require(isFinalized);
-    require(hasEnded());
     require(!funded());
 
     uint256 toReturn = purchases[msg.sender];
@@ -393,9 +393,8 @@ contract LifCrowdsale is Ownable, Pausable {
      Mechanism in case the soft cap was exceeded. It also unpauses the token to
      enable transfers. It can be called only once, after `end2Timestamp`
    */
-  function finalize() public {
+  function finalize() public hasEnded {
     require(!isFinalized);
-    require(hasEnded());
 
     // foward founds and unpause token only if minCap is reached
     if (funded()) {


### PR DESCRIPTION
Methods like validPurchase and hasEnded are converted to modifiers
funded is not converted to modifier because its bool return value is used in the logic of finalize

Fixes #251