### PR TITLE
Run coverage in travis in parallel to the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ node_js:
   - "7"
 cache:
   yarn: true
+env:
+  -
+  - SOLIDITY_COVERAGE=true
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: SOLIDITY_COVERAGE=true
 script:
-  - set -e
-  - yarn lint
-  - WT_DEBUG=true yarn test test/LifToken.js test/Crowdsale.js test/MarketValidationMechanism.js test/VestedPayment.js
-  - WT_DEBUG=true GEN_TESTS_QTY=40 yarn test test/CrowdsaleGenTest.js
-after_script:
-  - yarn run coveralls
+  - ./scripts/ci.sh

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if [ "$SOLIDITY_COVERAGE" = true ]; then
+  yarn run coveralls
+else
+  yarn lint
+  WT_DEBUG=true yarn test test/LifToken.js test/Crowdsale.js test/MarketValidationMechanism.js test/VestedPayment.js
+  WT_DEBUG=true GEN_TESTS_QTY=40 yarn test test/CrowdsaleGenTest.js
+fi


### PR DESCRIPTION
Allowing the coverage step to fail, makes the build to finish faster (at least the test part, which is the most important to have feedback from)

Fixes #178