### PR TITLE
MVM: Avoid delayed claim issue by adding claimable from reimbursed

### DIFF
--- a/contracts/LifMarketValidationMechanism.sol
+++ b/contracts/LifMarketValidationMechanism.sol
@@ -213,11 +213,15 @@ contract LifMarketValidationMechanism is Ownable {
     if (isFinished()) {
       return this.balance;
     } else {
+      uint256 claimableFromReimbursed = initialBuyPrice.
+        mul(totalBurnedTokens).div(PRICE_FACTOR).
+        sub(totalReimbursedWei);
       uint256 currentCirculation = lifToken.totalSupply();
       uint256 accumulatedDistributionPercentage = getAccumulatedDistributionPercentage();
       uint256 maxClaimable = initialWei.
         mul(accumulatedDistributionPercentage).div(PRICE_FACTOR).
-        mul(currentCirculation).div(originalTotalSupply);
+        mul(currentCirculation).div(originalTotalSupply).
+        add(claimableFromReimbursed);
 
       if (maxClaimable > totalWeiClaimed) {
         return maxClaimable.sub(totalWeiClaimed);

--- a/test/commands.js
+++ b/test/commands.js
@@ -640,11 +640,16 @@ let getMVMMaxClaimableWei = function(state) {
       minus(state.MVMClaimedWei).
       minus(state.returnedWeiForBurnedTokens);
   } else {
+    const claimableFromReimbursements = state.MVMInitialBuyPrice.
+      mul(state.MVMBurnedTokens).div(priceFactor).
+      minus(state.returnedWeiForBurnedTokens);
+
     const maxClaimable = state.MVMStartingBalance.
       mul(state.claimablePercentage).dividedBy(priceFactor).
       mul(state.initialTokenSupply - state.MVMBurnedTokens).
       dividedBy(state.initialTokenSupply).
-      minus(state.MVMClaimedWei);
+      minus(state.MVMClaimedWei).
+      plus(claimableFromReimbursements);
 
     return maxClaimable.gt(0) ? maxClaimable : new BigNumber(0);
   }


### PR DESCRIPTION
NOTE: This issue was only affecting the amount that the foundation would be able to claim from the MVM after there were some reimbursements made to token holders (via `sendTokens` transactions). We think the impact was not really high because it only delays the amount that the foundation could claim for the burned tokens (only for those tokens) depending on when the `sendTokens` tx is made:

- If the `sendTokens` tx is made early on the MVM lifetime, the amount that the foundation could claim from those tokens is super low, because of the distribution curve that follows an exponential distribution where the distribution amounts are low at the beginning and high approaching the end of the lifetime).

- If the `sendTokens` tx is made later, then even though the amount that the foundation could claim from those tokens would be higher, but having to wait until the end of MVM lifetime is not as high of an impact, precisely because the end of the MVM lifetime is close.

## Detailed explanation
Reimbursed ether in exchange of tokens in the MVM reduces the circulation which is involved in calculating the max claimable wei amount by the foundation, effectively delaying the amount claimable from those tokens until the MVM lifetime finishes. To recover that amount and avoid the delayed claim issue, we have to calculate and add the claimable from the burned tokens as the difference between the max amount claimable from those tokens (at the beginning of the MVM, using initialBuyPrice) and the amount effectively reimbursed.

---

Thanks to CoinFabrik for reporting this issue as part of their exhaustive LifToken audit!