### PR TITLE
Zeppelin-solidity 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.4",
     "solc": "0.4.15",
     "truffle-hdwallet-provider": "0.0.3",
-    "zeppelin-solidity": "1.2.0"
+    "zeppelin-solidity": "1.3.0"
   },
   "devDependencies": {
     "chai-bignumber": "^2.0.1",

--- a/test/commands.js
+++ b/test/commands.js
@@ -387,7 +387,7 @@ async function runTransferCommand(command, state) {
     toAddress = gen.getAccount(command.toAccount),
     fromBalance = getBalance(state, command.fromAccount),
     lifWei = help.lif2LifWei(command.lif),
-    hasZeroAddress = isZeroAddress(fromAddress),
+    hasZeroAddress = _.some([fromAddress, toAddress], isZeroAddress),
     shouldThrow = state.tokenPaused || fromBalance.lt(lifWei) ||
       hasZeroAddress;
 
@@ -447,7 +447,7 @@ async function runTransferFromCommand(command, state) {
     toAddress = gen.getAccount(command.toAccount),
     fromBalance = getBalance(state, command.fromAccount),
     lifWei = help.lif2LifWei(command.lif),
-    hasZeroAddress = _.some([senderAddress, fromAddress], isZeroAddress),
+    hasZeroAddress = _.some([senderAddress, fromAddress, toAddress], isZeroAddress),
     allowance = getAllowance(state, command.senderAccount, command.fromAccount);
 
   let shouldThrow = state.tokenPaused ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -4535,8 +4535,6 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-zeppelin-solidity@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.2.0.tgz#3a50c991a4da2f14fd79e66a2eb576407a6fb124"
-  dependencies:
-    truffle-hdwallet-provider "0.0.3"
+zeppelin-solidity@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.3.0.tgz#066ab35d7e07510da391d1dbaaf319e0d06fcfc6"


### PR DESCRIPTION
Fixes #265 

To make it sure there's no impact from changes in zeppelin-solidity base classes, I checked the diff from the classes that we use using the following command (in the zeppelin-solidity codebase):


    git diff v1.2.0..v1.3.0 contracts/token/ERC20.sol contracts/token/ERC20Basic.sol contracts/token/BasicToken.sol contracts/token/StandardToken.sol contracts/token/MintableToken.sol contracts/ownership/Ownable.sol contracts/math contracts/lifecycle/Migrations.sol contracts/lifecycle/Pausable.sol

(it would be nice if another pair of eyes also take a look)