### PR TITLE
Fix test command: Fund below soft cap can end creating a 48 months MVM

### DIFF
--- a/test/CrowdsaleGenTest.js
+++ b/test/CrowdsaleGenTest.js
@@ -706,6 +706,20 @@ contract('LifCrowdsale Property-based test', function(accounts) {
     });
   });
 
+  it('runs fund below cap, send tx and fund below cap with finalize test fine', async function() {
+    await runGeneratedCrowdsaleAndCommands({
+      commands: [
+        {'type':'fundCrowdsaleBelowSoftCap','account':10,'fundingEth':27,'finalize':false},
+        {'type':'sendTransaction','account':5,'beneficiary':5,'eth':3},
+        {'type':'fundCrowdsaleBelowSoftCap','account':8,'finalize':true}
+      ],
+      crowdsale: {
+        rate1: 37, rate2: 4, foundationWallet: 5, foundersWallet: 6,
+        setWeiLockSeconds: 840, owner: 4
+      }
+    });
+  });
+
   it('distributes tokens correctly on any combination of bids', async function() {
     // stateful prob based tests can take a long time to finish when shrinking...
     this.timeout(GEN_TESTS_TIMEOUT * 1000);

--- a/test/commands.js
+++ b/test/commands.js
@@ -127,7 +127,7 @@ async function runBuyTokensCommand(command, state) {
 async function runSendTransactionCommand(command, state) {
   let crowdsale = state.crowdsaleData,
     { startTimestamp, end2Timestamp } = crowdsale,
-    weiCost = parseInt(web3.toWei(command.eth, 'ether')),
+    weiCost = web3.toWei(new BigNumber(command.eth), 'ether'),
     nextTimestamp = latestTime(),
     rate = help.getCrowdsaleExpectedRate(crowdsale, nextTimestamp),
     tokens = new BigNumber(command.eth).mul(rate),

--- a/test/commands.js
+++ b/test/commands.js
@@ -649,7 +649,12 @@ async function runFundCrowdsaleBelowSoftCap(command, state) {
 
       if (currentUSDFunding.gte(softCap)) {
         assert(state.MVM);
-        assert.equal(24, parseInt(await state.MVM.totalPeriods()));
+        const capFor48Months = await state.crowdsaleContract.MVM24PeriodsCapUSD.call();
+        if (currentUSDFunding.gte(capFor48Months)) {
+          assert.equal(48, parseInt(await state.MVM.totalPeriods()));
+        } else {
+          assert.equal(24, parseInt(await state.MVM.totalPeriods()));
+        }
         assert.equal(state.crowdsaleData.foundationWallet, await state.MVM.foundationAddr());
       } else {
         // verify that there's no MVM

--- a/test/commands.js
+++ b/test/commands.js
@@ -157,7 +157,8 @@ async function runSendTransactionCommand(command, state) {
       throw(new Error('sendTransaction not in TGE should have thrown'));
     }
     state.totalSupply = state.totalSupply.plus(help.lif2LifWei(tokens));
-    state = decreaseEthBalance(state, command.account, weiCost.plus(help.txGasCost(tx)));
+    state = decreaseEthBalance(state, command.account, weiCost);
+    state = decreaseEthBalance(state, command.account, help.txGasCost(tx));
   } catch(e) {
     state = trackGasFromLastBlock(state, command.account);
     assertExpectedException(e, shouldThrow, hasZeroAddress, state, command);


### PR DESCRIPTION
Depending on the full test sequence, a fund below soft cap and finalize command can end creating a 48 months MVM, depending on the preceding sendTransation/buyTokens commands. This PR adds a test to verify this, and the fix in the `runFundCrowdsaleBelowSoftCap` test command