### PR TITLE
README coverage badge: add a request param to invalidate cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Líf is a SmartToken, based in the ERC20 standard with extra methods to send val
 This repository also has all the contracts related with the Token Generation Event (TGE), an strategy that combines a crowdsale, a market validation mechanism and vested payments.
 
 [![Build Status](https://travis-ci.org/windingtree/LifToken.svg?branch=master)](https://travis-ci.org/windingtree/LifToken)
-[![Coverage Status](https://coveralls.io/repos/github/windingtree/LifToken/badge.svg?branch=master)](https://coveralls.io/github/windingtree/LifToken?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/windingtree/LifToken/badge.svg?branch=master)](https://coveralls.io/github/windingtree/LifToken?branch=master&v=2.0)
 
 ## Requirements
 


### PR DESCRIPTION
It's the fix suggested in https://github.com/lemurheavy/coveralls-public/issues/116#issuecomment-333808216 to overcome the github aggresive caching that doesn't play well with coverage badge (it stays too long at the same value)