### PR TITLE
chore: Pins travis CI auto releases to windingtree repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ deploy:
   skip_cleanup: true
   api_key: $NPM_TOKEN
   on:
-    branch: master
+    repo: windingtree/LifToken
     tags: true


### PR DESCRIPTION
This will prevent publishing to npm from forks. The previous setup was actually wrong.